### PR TITLE
Add configuration support for custom LLM endpoints (LM Studio, Ollama)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,17 @@ claude-companion
 # Run with uv (no install needed)
 uv run claude-companion
 
+# Hook management
+claude-companion install        # Install hooks to ~/.claude/settings.json
+claude-companion uninstall      # Remove hooks
+claude-companion status         # Check hook installation
+
+# LLM configuration (for summarization)
+claude-companion config --show                    # Show current config
+claude-companion config --preset lm-studio        # Use LM Studio preset
+claude-companion config --preset ollama           # Use Ollama preset
+claude-companion config --url URL --model MODEL   # Custom configuration
+
 # Test imports
 uv run python -c "from claude_companion import tui, store, models; print('OK')"
 ```
@@ -34,12 +45,19 @@ uv run python -c "from claude_companion import tui, store, models; print('OK')"
 
 ### Key Components
 
-- **`store.py`** - Central `EventStore` class: thread-safe session/turn storage, listener pattern for updates, coordinates watcher and alerts
+- **`store.py`** - Central `EventStore` class: thread-safe session/turn storage, listener pattern for updates, coordinates watcher/alerts/summarizer
 - **`watcher.py`** - `TranscriptWatcher`: polls transcript file, parses JSONL entries into `Turn` objects
+- **`transcript.py`** - Parses `session.jsonl` files to load conversation history on session start
 - **`models.py`** - Data classes: `Event` (raw hook data), `Turn` (conversation turn), `Session` (groups turns)
 - **`tui.py`** - Rich-based TUI: renders sessions, turns, handles keyboard input
 - **`hooks.py`** - Installs/uninstalls curl hooks in `~/.claude/settings.json`
 - **`alerts.py`** - Pattern matching for dangerous operations (force push, rm -rf, etc.)
+- **`summarizer.py`** - Optional LLM summarization of assistant turns via OpenAI-compatible server
+- **`cache.py`** - Persistent disk cache for summaries (`~/.cache/claude-companion/summaries.json`)
+- **`config.py`** - Configuration management for LLM server settings (supports env vars, config file, defaults)
+- **`export.py`** - Export session data to Markdown or JSON formats
+- **`server.py`** - Flask HTTP server that receives hook events
+- **`cli.py`** - Click-based CLI with commands: `install`, `uninstall`, `status`, `config`
 
 ### Hook Design
 
@@ -50,4 +68,21 @@ Only `SessionStart` hook is needed. All conversation content (user messages, ass
 - Main thread: TUI rendering loop
 - Server thread: Flask HTTP server (daemon)
 - Watcher thread: Transcript file polling (daemon)
+- Summarizer threads: ThreadPoolExecutor for async LLM calls (2 workers)
 - All shared state in `EventStore` protected by `threading.Lock`
+
+### Optional Features
+
+**LLM Summarization**: Assistant turns can be summarized using any OpenAI-compatible local LLM server. Supported options:
+- **LM Studio** (recommended for Mac): `http://localhost:1234/v1`
+- **Ollama**: `http://localhost:11434/v1`
+- **vLLM**: `http://localhost:8008/v1` (default)
+
+Configuration priority:
+1. Environment variables: `CLAUDE_COMPANION_LLM_URL`, `CLAUDE_COMPANION_LLM_MODEL`
+2. Config file: `~/.claude-companion/config.json`
+3. Hardcoded defaults (vLLM)
+
+Use `claude-companion config` to set up your LLM server. Summaries are cached to disk and persist across sessions. The feature gracefully degrades if the server is unavailable.
+
+**Export**: Sessions can be exported to Markdown or JSON via the `export.py` module (used by TUI keyboard shortcuts).

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The companion will automatically detect and display your Claude Code session.
 | `claude-companion install` | Install Claude Code hooks |
 | `claude-companion uninstall` | Remove Claude Code hooks |
 | `claude-companion status` | Check hook installation status |
+| `claude-companion config` | Configure LLM server for summarization |
 
 ## Options
 
@@ -47,11 +48,55 @@ The companion will automatically detect and display your Claude Code session.
 | `--port`, `-p` | HTTP server port (default: 5432) |
 | `--version`, `-v` | Show version |
 
+## LLM Summarization (Optional)
+
+The companion can summarize assistant responses using a local LLM. Supports:
+
+- **LM Studio** (recommended for Mac)
+- **Ollama**
+- **vLLM**
+
+### Setup with LM Studio
+
+```bash
+# 1. Start LM Studio and load a model
+# 2. Enable the local server in LM Studio (default: http://localhost:1234)
+# 3. Configure the companion
+claude-companion config --preset lm-studio
+
+# Or use custom settings
+claude-companion config --url http://localhost:1234/v1 --model your-model-name
+```
+
+### Setup with Ollama
+
+```bash
+# 1. Install Ollama: brew install ollama
+# 2. Start Ollama: ollama serve
+# 3. Pull a model: ollama pull qwen2.5:7b
+# 4. Configure the companion
+claude-companion config --preset ollama
+```
+
+### Environment Variables
+
+You can also configure via environment variables:
+
+```bash
+export CLAUDE_COMPANION_LLM_URL="http://localhost:1234/v1"
+export CLAUDE_COMPANION_LLM_MODEL="openai/gpt-oss-20b"
+claude-companion
+```
+
 ## TUI Keybindings
 
 | Key | Action |
 |-----|--------|
 | `1-9` | Switch between sessions |
+| `j/k` | Navigate turns |
+| `o` | Expand/collapse turn |
+| `s` | Toggle summary mode |
+| `f` | Filter turns |
 | `q` | Quit |
 | `r` | Refresh display |
 

--- a/src/claude_companion/cli.py
+++ b/src/claude_companion/cli.py
@@ -5,6 +5,7 @@ from rich.console import Console
 from rich.table import Table
 
 from . import __version__
+from .config import CONFIG_FILE, get_example_configs, load_config, save_config, Config, LLMConfig
 from .hooks import check_hooks_status, install_hooks, uninstall_hooks
 from .server import ServerThread
 from .store import EventStore
@@ -137,6 +138,79 @@ def status(port: int) -> None:
         console.print("\n[green]All hooks installed![/green]")
     else:
         console.print("\nRun [bold]claude-companion install[/bold] to install missing hooks.")
+
+
+@main.command()
+@click.option("--url", help="LLM server base URL (e.g., http://localhost:1234/v1)")
+@click.option("--model", help="LLM model name (e.g., openai/gpt-oss-20b)")
+@click.option("--preset", type=click.Choice(["vllm", "lm-studio", "ollama"]), help="Use preset configuration")
+@click.option("--show", is_flag=True, help="Show current configuration")
+def config(url: str | None, model: str | None, preset: str | None, show: bool) -> None:
+    """Configure LLM server for summarization.
+
+    Examples:
+      claude-companion config --preset lm-studio
+      claude-companion config --url http://localhost:1234/v1 --model openai/gpt-oss-20b
+      claude-companion config --show
+    """
+    if show:
+        # Show current configuration
+        current_config = load_config()
+        console.print("\n[bold]Current LLM Configuration:[/bold]")
+        console.print(f"  Base URL: [cyan]{current_config.llm.base_url}[/cyan]")
+        console.print(f"  Model:    [cyan]{current_config.llm.model}[/cyan]")
+        console.print(f"\nConfig file: [dim]{CONFIG_FILE}[/dim]")
+
+        # Show environment variable overrides if set
+        import os
+        if os.getenv("CLAUDE_COMPANION_LLM_URL"):
+            console.print(f"\n[yellow]Note:[/yellow] CLAUDE_COMPANION_LLM_URL is set: {os.getenv('CLAUDE_COMPANION_LLM_URL')}")
+        if os.getenv("CLAUDE_COMPANION_LLM_MODEL"):
+            console.print(f"[yellow]Note:[/yellow] CLAUDE_COMPANION_LLM_MODEL is set: {os.getenv('CLAUDE_COMPANION_LLM_MODEL')}")
+
+        return
+
+    if preset:
+        # Use preset configuration
+        examples = get_example_configs()
+        if preset not in examples:
+            console.print(f"[red]Error:[/red] Unknown preset '{preset}'")
+            return
+
+        preset_config = examples[preset]
+        url = preset_config["base_url"]
+        model = preset_config["model"]
+        console.print(f"Using [cyan]{preset_config['description']}[/cyan] preset")
+
+    if not url and not model:
+        # Show available presets
+        console.print("\n[bold]Available Presets:[/bold]\n")
+        examples = get_example_configs()
+        for name, cfg in examples.items():
+            console.print(f"  [cyan]{name}[/cyan]: {cfg['description']}")
+            console.print(f"    URL:   {cfg['base_url']}")
+            console.print(f"    Model: {cfg['model']}\n")
+
+        console.print("Use --preset to apply a preset, or --url/--model to set custom values.")
+        console.print("Use --show to view current configuration.")
+        return
+
+    # Load current config
+    current_config = load_config()
+
+    # Update with new values
+    new_url = url if url else current_config.llm.base_url
+    new_model = model if model else current_config.llm.model
+
+    new_config = Config(llm=LLMConfig(base_url=new_url, model=new_model))
+
+    # Save configuration
+    save_config(new_config)
+
+    console.print("\n[green]Configuration saved![/green]")
+    console.print(f"  Base URL: [cyan]{new_config.llm.base_url}[/cyan]")
+    console.print(f"  Model:    [cyan]{new_config.llm.model}[/cyan]")
+    console.print(f"\nSaved to: [dim]{CONFIG_FILE}[/dim]")
 
 
 if __name__ == "__main__":

--- a/src/claude_companion/config.py
+++ b/src/claude_companion/config.py
@@ -1,0 +1,102 @@
+"""Configuration management for Claude Companion."""
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class LLMConfig:
+    """LLM server configuration for summarization."""
+
+    base_url: str
+    model: str
+
+
+@dataclass
+class Config:
+    """Claude Companion configuration."""
+
+    llm: LLMConfig
+
+
+# Default configuration
+DEFAULT_CONFIG = Config(
+    llm=LLMConfig(
+        base_url="http://localhost:8008/v1",  # vLLM default
+        model="Qwen/Qwen3-30B-A3B-Instruct-2507",
+    )
+)
+
+# Config file path
+CONFIG_DIR = Path.home() / ".claude-companion"
+CONFIG_FILE = CONFIG_DIR / "config.json"
+
+
+def load_config() -> Config:
+    """Load configuration from environment, file, or defaults.
+
+    Priority (highest to lowest):
+    1. Environment variables (CLAUDE_COMPANION_LLM_URL, CLAUDE_COMPANION_LLM_MODEL)
+    2. Config file (~/.claude-companion/config.json)
+    3. Hardcoded defaults
+    """
+    # Start with defaults
+    llm_url = DEFAULT_CONFIG.llm.base_url
+    llm_model = DEFAULT_CONFIG.llm.model
+
+    # Try loading from config file
+    if CONFIG_FILE.exists():
+        try:
+            with open(CONFIG_FILE) as f:
+                data = json.load(f)
+                llm_data = data.get("llm", {})
+                llm_url = llm_data.get("base_url", llm_url)
+                llm_model = llm_data.get("model", llm_model)
+        except Exception:
+            # Silently fall back to defaults if config file is malformed
+            pass
+
+    # Environment variables override everything
+    llm_url = os.getenv("CLAUDE_COMPANION_LLM_URL", llm_url)
+    llm_model = os.getenv("CLAUDE_COMPANION_LLM_MODEL", llm_model)
+
+    return Config(llm=LLMConfig(base_url=llm_url, model=llm_model))
+
+
+def save_config(config: Config) -> None:
+    """Save configuration to file."""
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+
+    data: dict[str, Any] = {
+        "llm": {
+            "base_url": config.llm.base_url,
+            "model": config.llm.model,
+        }
+    }
+
+    with open(CONFIG_FILE, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def get_example_configs() -> dict[str, dict[str, str]]:
+    """Get example configurations for common LLM providers."""
+    return {
+        "vllm": {
+            "base_url": "http://localhost:8008/v1",
+            "model": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+            "description": "vLLM server (default)",
+        },
+        "lm-studio": {
+            "base_url": "http://localhost:1234/v1",
+            "model": "openai/gpt-oss-20b",
+            "description": "LM Studio",
+        },
+        "ollama": {
+            "base_url": "http://localhost:11434/v1",
+            "model": "qwen2.5:7b",
+            "description": "Ollama",
+        },
+    }

--- a/src/claude_companion/store.py
+++ b/src/claude_companion/store.py
@@ -6,6 +6,7 @@ from typing import Callable
 
 from .alerts import Alert, AlertLevel, check_event_for_alerts, check_turn_for_alerts, send_system_notification
 from .cache import SummaryCache
+from .config import load_config
 from .models import Event, Session, Turn
 from .summarizer import Summarizer
 from .transcript import parse_transcript
@@ -25,7 +26,13 @@ class EventStore:
         self._active_session_id: str | None = None
         self._enable_notifications = enable_notifications
         self._watcher = TranscriptWatcher(self._on_watcher_turn)
-        self._summarizer = Summarizer()
+
+        # Load config and initialize summarizer
+        config = load_config()
+        self._summarizer = Summarizer(
+            base_url=config.llm.base_url,
+            model=config.llm.model,
+        )
         self._summary_cache = SummaryCache()
 
     def add_event(self, event: Event) -> None:

--- a/src/claude_companion/summarizer.py
+++ b/src/claude_companion/summarizer.py
@@ -1,4 +1,4 @@
-"""LLM summarization for assistant turns using vLLM server."""
+"""LLM summarization for assistant turns using OpenAI-compatible server."""
 
 import logging
 from concurrent.futures import ThreadPoolExecutor
@@ -10,18 +10,14 @@ from .models import Turn
 
 logger = logging.getLogger(__name__)
 
-# Default vLLM server configuration
-DEFAULT_BASE_URL = "http://localhost:8008/v1"
-DEFAULT_MODEL = "Qwen/Qwen3-30B-A3B-Instruct-2507"
-
 
 class Summarizer:
-    """Summarizes assistant turns using a local vLLM server."""
+    """Summarizes assistant turns using an OpenAI-compatible server (vLLM, LM Studio, Ollama)."""
 
     def __init__(
         self,
-        base_url: str = DEFAULT_BASE_URL,
-        model: str = DEFAULT_MODEL,
+        base_url: str,
+        model: str,
         max_workers: int = 2,
     ):
         self.base_url = base_url.rstrip("/")


### PR DESCRIPTION
## Summary

Adds configuration support for custom LLM endpoints, making it easy to use LM Studio, Ollama, or any OpenAI-compatible server for summarization instead of requiring a hardcoded vLLM server.

## Changes

### New Features

- **`config.py`** - New configuration module with:
  - Environment variable support (`CLAUDE_COMPANION_LLM_URL`, `CLAUDE_COMPANION_LLM_MODEL`)
  - Config file support (`~/.claude-companion/config.json`)
  - Fallback to hardcoded defaults (vLLM)
  
- **`claude-companion config` CLI command** with:
  - `--preset` option for quick setup (lm-studio, ollama, vllm)
  - `--url` and `--model` for custom configuration
  - `--show` to display current configuration

### Updated Components

- **`summarizer.py`** - Now accepts `base_url` and `model` as constructor parameters (removed hardcoded defaults)
- **`store.py`** - Loads config on initialization and passes to summarizer
- **Documentation** - Updated CLAUDE.md and README.md with configuration instructions

## Usage Examples

```bash
# Quick setup with LM Studio
claude-companion config --preset lm-studio

# Custom configuration
claude-companion config --url http://localhost:1234/v1 --model openai/gpt-oss-20b

# Show current config
claude-companion config --show

# Environment variable override
export CLAUDE_COMPANION_LLM_URL="http://localhost:1234/v1"
export CLAUDE_COMPANION_LLM_MODEL="openai/gpt-oss-20b"
claude-companion
```

## Testing

Tested with:
- ✅ LM Studio on macOS (http://127.0.0.1:1234/v1 with openai/gpt-oss-20b)
- ✅ Config file creation and loading
- ✅ Environment variable overrides
- ✅ Preset configurations
- ✅ Summary generation with LM Studio backend

## Closes

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)