### PR TITLE
Fix green bullet color to match Claude Code

### DIFF
--- a/src/claude_companion/styles.py
+++ b/src/claude_companion/styles.py
@@ -253,7 +253,7 @@ class ClaudeCodeStyle(StyleRenderer):
     BULLET = "⏺"
     BULLET_STYLES = {
         "assistant": "white",
-        "tool": "green",
+        "tool": "#5fd787",  # Matches Claude Code's green bullet
     }
 
     TOOL_INDICATORS = {


### PR DESCRIPTION
## Summary
- Update tool bullet color from `"green"` to `"#5fd787"` (spring green) in ClaudeCodeStyle
- The previous "green" was too muted/olive compared to Claude Code's vibrant green bullet

Fixes #29

## Test plan
- [x] Run claude-companion with `claude-code` style
- [x] Verify the green bullet color matches Claude Code's interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)