### PR TITLE
Add WIP commit detection to code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,9 +29,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
+      - name: Check for WIP commit
+        id: check-wip
+        run: |
+          COMMIT_MSG=$(git log -1 --pretty=%s)
+          echo "Last commit message: $COMMIT_MSG"
+          if [[ "$COMMIT_MSG" == \[wip\]* ]] || [[ "$COMMIT_MSG" == \[WIP\]* ]]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "Skipping review: commit marked as work in progress"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Run Claude Code Review
+        if: steps.check-wip.outputs.skip != 'true'
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
## Summary
- Add detection for work-in-progress commits in the Claude Code Review workflow
- Skip review execution when commit message starts with `[wip]` or `[WIP]`
- Explicitly checkout PR head SHA for consistent behavior

## Motivation
Allows developers to push incremental work-in-progress changes without triggering code reviews until they're ready. Simply prefix commit messages with `[wip]` to skip the review.

## Changes
- Added `Check for WIP commit` step to parse the last commit message
- Made the review step conditional based on WIP detection
- Updated checkout to use explicit PR head SHA reference

## Test plan
- [ ] Push a commit with `[wip]` prefix and verify review is skipped
- [ ] Push a regular commit and verify review runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)