### PR TITLE
Fix session tracking lost when switching between multiple Claude instances

### DIFF
--- a/src/claude_companion/tui.py
+++ b/src/claude_companion/tui.py
@@ -404,6 +404,7 @@ class TUI:
             "[dim]m[/dim]:monitor "
             "[dim]?[/dim]:ask "
             "[dim]x[/dim]:export "
+            "[dim]D[/dim]:delete "
             "[dim]q[/dim]:quit"
         )
 
@@ -638,6 +639,21 @@ class TUI:
             else:
                 self._show_status("No historical turns need summarization")
             self._refresh_event.set()
+
+        elif key == "D":  # Delete active session
+            session = self.store.get_active_session()
+            if session:
+                session_id = session.session_id
+                if self.store.delete_session(session_id):
+                    self._show_status(f"Deleted session {session_id[:8]}...")
+                    # Reset UI state
+                    self._selected_index = None
+                    self._scroll_offset = 0
+                    self._filter_index = 0
+                    self._auto_scroll = True
+                    self._refresh_event.set()
+            else:
+                self._show_status("No session to delete")
 
         return True
 


### PR DESCRIPTION
## Summary
Fixes #64 - Session tracking lost when switching between multiple Claude instances

## Problem
When multiple Claude Code sessions were running simultaneously, the companion would lose track of older sessions when new ones started. Only the most recent session would continue to be monitored.

## Root Cause
`EventStore` maintained only a single `TranscriptWatcher` instance shared across all sessions. When a new session started, calling `watcher.watch()` with the new transcript path would replace the previous path being monitored.

## Solution
Refactored to maintain a **separate watcher for each session**:

### Key Changes in `store.py`
- ✅ Changed from single `_watcher` to `_transcript_watchers: dict[str, TranscriptWatcher]` 
- ✅ Each session gets its own `TranscriptWatcher` instance with session_id captured in callback
- ✅ Updated `_on_watcher_turn()` to accept `session_id` parameter and route turns to correct session
- ✅ Updated `stop()` to stop all transcript watchers
- ✅ Applied same pattern to both `add_event()` (SessionStart) and `load_session_from_transcript()` (resume)

## Testing
- ✅ Created and ran test confirming multiple watchers are created and maintained
- ✅ User verified fix works with actual multiple Claude instances

## Result
All active sessions continue to be monitored simultaneously, regardless of when new sessions start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)