### PR TITLE
Fix: Load only most recent session by default

### DIFF
--- a/src/claude_companion/cli.py
+++ b/src/claude_companion/cli.py
@@ -77,12 +77,12 @@ def run_companion(global_mode: bool = False, ui_style: str = DEFAULT_STYLE, coll
         return
 
     # Create store and start watching
-    # In global mode, limit to 9 most recent sessions (can be selected with keys 1-9)
-    max_sessions = 9 if global_mode else None
+    # Load only most recent session by default; new sessions auto-detected while running
+    max_sessions = 1
     store = EventStore()
     store.start_watching(project_paths, max_sessions=max_sessions)
 
-    scope = "all projects (9 most recent)" if global_mode else "current directory"
+    scope = "all projects" if global_mode else "current directory"
     console.print(f"[dim]Watching {scope} for Claude sessions...[/dim]")
 
     try:


### PR DESCRIPTION
## Summary
- Fixes #74
- Changes session loading to only load 1 most recent session in both global and non-global modes
- Eliminates UI clutter from loading 9+ old inactive sessions

## Changes
- `cli.py:81` - Set `max_sessions = 1` for both modes (was `9 if global_mode else None`)
- Updated comment to clarify behavior
- Updated console output message

## Behavior
**Before:**
- Non-global mode: Loaded ALL past sessions (unlimited)
- Global mode: Loaded 9 most recent sessions
- Result: UI cluttered with old sessions you're not using

**After:**
- Both modes: Load only 1 most recent session
- New sessions: Auto-detected while companion runs
- Result: Clean UI focused on current/active work

## Testing
Tested with `uv run claude-companion` - now shows only most recent session ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)