### PR TITLE
Add critic feature to evaluate assistant responses

### DIFF
--- a/src/claude_companion/export.py
+++ b/src/claude_companion/export.py
@@ -36,6 +36,12 @@ def export_session_markdown(session: Session, output_path: Path | None = None) -
             lines.append(f"### Turn {turn.turn_number} - Tool: {turn.tool_name}")
 
         lines.append("")
+        if turn.summary:
+            lines.append(f"**Summary**: {turn.summary}")
+            lines.append("")
+        if turn.critic:
+            lines.append(f"**Critic**: {turn.critic}")
+            lines.append("")
         lines.append(turn.content_full)
         lines.append("")
 
@@ -66,6 +72,9 @@ def export_session_json(session: Session, output_path: Path | None = None) -> st
                 "role": turn.role,
                 "tool_name": turn.tool_name,
                 "content": turn.content_full,
+                "summary": turn.summary,
+                "critic": turn.critic,
+                "critic_sentiment": turn.critic_sentiment,
                 "word_count": turn.word_count,
                 "timestamp": turn.timestamp.isoformat(),
             }

--- a/src/claude_companion/models.py
+++ b/src/claude_companion/models.py
@@ -26,6 +26,8 @@ class Turn:
     expanded: bool = False
     is_historical: bool = False  # True if loaded from transcript history
     summary: str | None = None  # LLM-generated summary for assistant turns
+    critic: str | None = None  # LLM-generated critique for assistant turns
+    critic_sentiment: str | None = None  # "progress" | "concern" | "critical"
     task_operation: tuple[str, dict[str, Any]] | None = None  # (operation_type, data) for task tools
 
 


### PR DESCRIPTION
## Summary

Implements Phase 1 of the critic feature that evaluates assistant turns in real-time to assess progress toward user goals and flag potential issues.

### Key Features

- **Real-time evaluation**: Critiques every non-historical assistant turn as it arrives
- **Contextual analysis**: Uses user request, active tasks, and assistant response for evaluation
- **Visual feedback**: Color-coded sentiments (✓ green for progress, ⚠ yellow for concern, ✗ red for critical)
- **Smart caching**: Persistent cache with composite keys (content + context)
- **Graceful degradation**: Falls back cleanly if LLM server unavailable
- **Multi-provider support**: Works with local, OpenAI, OpenRouter, and Anthropic providers

### Changes

- **models.py**: Added `critic` and `critic_sentiment` fields to `Turn` dataclass
- **summarizer.py**: Added critic logic with `_critique()` method, context extraction, and cache key generation
- **store.py**: Integrated critic into event handling with caching support
- **tui_textual.py**: Updated both Rich and Claude Code rendering styles to display critiques
- **export.py**: Added critic fields to Markdown and JSON exports

### Display Behavior

- Critic appears below assistant summary when turn is collapsed
- Hides when turn is expanded (full content visible)
- Works in both Rich and Claude Code display styles

## Test plan

- [x] Syntax validation passes (`uv run python -c "from claude_companion import ..."`)
- [ ] Start `claude-companion` and verify critics appear below assistant responses
- [ ] Check color coding matches sentiment
- [ ] Test expand/collapse behavior
- [ ] Verify cache persistence across restarts
- [ ] Export session and verify critic fields included

🤖 Generated with [Claude Code](https://claude.com/claude-code)