### PR TITLE
Add annotation feature to annotate any turn (#23)

### DIFF
--- a/src/claude_companion/cache.py
+++ b/src/claude_companion/cache.py
@@ -1,4 +1,4 @@
-"""Persistent cache for summaries."""
+"""Persistent cache for summaries and annotations."""
 
 import hashlib
 import json
@@ -9,7 +9,8 @@ from threading import Lock
 logger = logging.getLogger(__name__)
 
 DEFAULT_CACHE_DIR = Path.home() / ".cache" / "claude-companion"
-CACHE_FILENAME = "summaries.json"
+SUMMARIES_FILENAME = "summaries.json"
+ANNOTATIONS_FILENAME = "annotations.json"
 
 
 def content_hash(content: str) -> str:
@@ -22,7 +23,7 @@ class SummaryCache:
 
     def __init__(self, cache_dir: Path = DEFAULT_CACHE_DIR):
         self._cache_dir = cache_dir
-        self._cache_file = cache_dir / CACHE_FILENAME
+        self._cache_file = cache_dir / SUMMARIES_FILENAME
         self._cache: dict[str, str] = {}
         self._lock = Lock()
         self._load()
@@ -63,5 +64,71 @@ class SummaryCache:
 
     def __len__(self) -> int:
         """Return number of cached summaries."""
+        with self._lock:
+            return len(self._cache)
+
+
+def annotation_key(session_id: str, turn_number: int) -> str:
+    """Generate key for annotation lookup."""
+    return f"{session_id}:{turn_number}"
+
+
+class AnnotationCache:
+    """Thread-safe persistent cache for user annotations."""
+
+    def __init__(self, cache_dir: Path = DEFAULT_CACHE_DIR):
+        self._cache_dir = cache_dir
+        self._cache_file = cache_dir / ANNOTATIONS_FILENAME
+        self._cache: dict[str, str] = {}
+        self._lock = Lock()
+        self._load()
+
+    def _load(self) -> None:
+        """Load cache from disk."""
+        if not self._cache_file.exists():
+            return
+        try:
+            with open(self._cache_file, "r") as f:
+                self._cache = json.load(f)
+            logger.debug(f"Loaded {len(self._cache)} cached annotations")
+        except (json.JSONDecodeError, IOError) as e:
+            logger.warning(f"Failed to load annotation cache: {e}")
+            self._cache = {}
+
+    def _save(self) -> None:
+        """Save cache to disk."""
+        try:
+            self._cache_dir.mkdir(parents=True, exist_ok=True)
+            with open(self._cache_file, "w") as f:
+                json.dump(self._cache, f)
+        except IOError as e:
+            logger.warning(f"Failed to save annotation cache: {e}")
+
+    def get(self, session_id: str, turn_number: int) -> str | None:
+        """Get cached annotation for a turn."""
+        key = annotation_key(session_id, turn_number)
+        with self._lock:
+            return self._cache.get(key)
+
+    def set(self, session_id: str, turn_number: int, annotation: str) -> None:
+        """Store annotation for a turn."""
+        key = annotation_key(session_id, turn_number)
+        with self._lock:
+            if annotation:
+                self._cache[key] = annotation
+            elif key in self._cache:
+                del self._cache[key]
+            self._save()
+
+    def delete(self, session_id: str, turn_number: int) -> None:
+        """Delete annotation for a turn."""
+        key = annotation_key(session_id, turn_number)
+        with self._lock:
+            if key in self._cache:
+                del self._cache[key]
+                self._save()
+
+    def __len__(self) -> int:
+        """Return number of cached annotations."""
         with self._lock:
             return len(self._cache)

--- a/src/claude_companion/export.py
+++ b/src/claude_companion/export.py
@@ -42,6 +42,9 @@ def export_session_markdown(session: Session, output_path: Path | None = None) -
         if turn.critic:
             lines.append(f"**Critic**: {turn.critic}")
             lines.append("")
+        if turn.annotation:
+            lines.append(f"**Annotation**: {turn.annotation}")
+            lines.append("")
         lines.append(turn.content_full)
         lines.append("")
 
@@ -75,6 +78,7 @@ def export_session_json(session: Session, output_path: Path | None = None) -> st
                 "summary": turn.summary,
                 "critic": turn.critic,
                 "critic_sentiment": turn.critic_sentiment,
+                "annotation": turn.annotation,
                 "word_count": turn.word_count,
                 "timestamp": turn.timestamp.isoformat(),
             }

--- a/src/claude_companion/models.py
+++ b/src/claude_companion/models.py
@@ -29,6 +29,7 @@ class Turn:
     critic: str | None = None  # LLM-generated critique for assistant turns
     critic_sentiment: str | None = None  # "progress" | "concern" | "critical"
     task_operation: tuple[str, dict[str, Any]] | None = None  # (operation_type, data) for task tools
+    annotation: str | None = None  # User-provided annotation
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- Add `annotation` field to `Turn` model for user-provided notes
- Add `AnnotationCache` for persistent storage in `~/.cache/claude-companion/annotations.json`
- Add `n` keybinding to annotate the selected turn in TUI
- Display annotations with 📝 icon in yellow for all turn types (user, assistant, tool, tool groups)
- Include annotations in Markdown and JSON exports
- Preserve scroll position after saving annotation

## Usage

1. Navigate to a turn using `j`/`k` keys
2. Press `n` to focus the annotation input
3. Type your annotation and press Enter to save
4. To clear an annotation, press `n`, clear the text, and press Enter

## Test plan

- [x] Verify annotation can be added to user turns
- [x] Verify annotation can be added to assistant turns
- [x] Verify annotation can be added to tool turns
- [x] Verify annotation can be added to tool groups (collapsed view)
- [x] Verify annotations persist across sessions
- [x] Verify scroll position is preserved after annotation
- [x] Verify annotations appear in exports

Closes #23

🤖 Generated with [Claude Code](https://claude.ai/code)