### PR TITLE
Add file locking for cache files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "click>=8.0",
+    "filelock>=3.0",
     "requests>=2.28",
     "rich>=13.0",
     "openai>=1.0",

--- a/src/claude_companion/cache.py
+++ b/src/claude_companion/cache.py
@@ -6,6 +6,8 @@ import logging
 from pathlib import Path
 from threading import Lock
 
+from filelock import FileLock
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_CACHE_DIR = Path.home() / ".cache" / "claude-companion"
@@ -19,52 +21,71 @@ def content_hash(content: str) -> str:
 
 
 class SummaryCache:
-    """Thread-safe persistent cache for turn summaries."""
+    """Thread-safe persistent cache for turn summaries with file locking."""
 
     def __init__(self, cache_dir: Path = DEFAULT_CACHE_DIR):
         self._cache_dir = cache_dir
         self._cache_file = cache_dir / SUMMARIES_FILENAME
+        self._lock_file = cache_dir / f"{SUMMARIES_FILENAME}.lock"
         self._cache: dict[str, str] = {}
-        self._lock = Lock()
+        self._thread_lock = Lock()
         self._load()
 
-    def _load(self) -> None:
-        """Load cache from disk."""
+    def _read_from_disk(self) -> dict[str, str]:
+        """Read cache from disk without locking."""
         if not self._cache_file.exists():
-            return
+            return {}
         try:
             with open(self._cache_file, "r") as f:
-                self._cache = json.load(f)
-            logger.debug(f"Loaded {len(self._cache)} cached summaries")
+                return json.load(f)
         except (json.JSONDecodeError, IOError) as e:
-            logger.warning(f"Failed to load summary cache: {e}")
-            self._cache = {}
+            logger.warning(f"Failed to read summary cache: {e}")
+            return {}
 
-    def _save(self) -> None:
-        """Save cache to disk."""
+    def _write_to_disk(self, data: dict[str, str]) -> None:
+        """Write cache to disk without locking."""
         try:
             self._cache_dir.mkdir(parents=True, exist_ok=True)
             with open(self._cache_file, "w") as f:
-                json.dump(self._cache, f)
+                json.dump(data, f)
         except IOError as e:
-            logger.warning(f"Failed to save summary cache: {e}")
+            logger.warning(f"Failed to write summary cache: {e}")
+
+    def _load(self) -> None:
+        """Load cache from disk with file lock."""
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+        with FileLock(self._lock_file):
+            self._cache = self._read_from_disk()
+            if self._cache:
+                logger.debug(f"Loaded {len(self._cache)} cached summaries")
+
+    def _save(self) -> None:
+        """Save cache to disk with file locking and merge."""
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+        with FileLock(self._lock_file):
+            # Re-read to get any changes from other instances
+            disk_cache = self._read_from_disk()
+            # Merge: summaries are content-addressed, so simple merge is safe
+            merged = {**disk_cache, **self._cache}
+            self._write_to_disk(merged)
+            self._cache = merged
 
     def get(self, content: str) -> str | None:
         """Get cached summary for content."""
         key = content_hash(content)
-        with self._lock:
+        with self._thread_lock:
             return self._cache.get(key)
 
     def set(self, content: str, summary: str) -> None:
         """Store summary for content."""
         key = content_hash(content)
-        with self._lock:
+        with self._thread_lock:
             self._cache[key] = summary
             self._save()
 
     def __len__(self) -> int:
         """Return number of cached summaries."""
-        with self._lock:
+        with self._thread_lock:
             return len(self._cache)
 
 
@@ -74,61 +95,91 @@ def annotation_key(session_id: str, turn_number: int) -> str:
 
 
 class AnnotationCache:
-    """Thread-safe persistent cache for user annotations."""
+    """Thread-safe persistent cache for user annotations with file locking."""
 
     def __init__(self, cache_dir: Path = DEFAULT_CACHE_DIR):
         self._cache_dir = cache_dir
         self._cache_file = cache_dir / ANNOTATIONS_FILENAME
+        self._lock_file = cache_dir / f"{ANNOTATIONS_FILENAME}.lock"
         self._cache: dict[str, str] = {}
-        self._lock = Lock()
+        self._deleted_keys: set[str] = set()  # Track deletions for merge
+        self._thread_lock = Lock()
         self._load()
 
-    def _load(self) -> None:
-        """Load cache from disk."""
+    def _read_from_disk(self) -> dict[str, str]:
+        """Read cache from disk without locking."""
         if not self._cache_file.exists():
-            return
+            return {}
         try:
             with open(self._cache_file, "r") as f:
-                self._cache = json.load(f)
-            logger.debug(f"Loaded {len(self._cache)} cached annotations")
+                return json.load(f)
         except (json.JSONDecodeError, IOError) as e:
-            logger.warning(f"Failed to load annotation cache: {e}")
-            self._cache = {}
+            logger.warning(f"Failed to read annotation cache: {e}")
+            return {}
 
-    def _save(self) -> None:
-        """Save cache to disk."""
+    def _write_to_disk(self, data: dict[str, str]) -> None:
+        """Write cache to disk without locking."""
         try:
             self._cache_dir.mkdir(parents=True, exist_ok=True)
             with open(self._cache_file, "w") as f:
-                json.dump(self._cache, f)
+                json.dump(data, f)
         except IOError as e:
-            logger.warning(f"Failed to save annotation cache: {e}")
+            logger.warning(f"Failed to write annotation cache: {e}")
+
+    def _load(self) -> None:
+        """Load cache from disk with file lock."""
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+        with FileLock(self._lock_file):
+            self._cache = self._read_from_disk()
+            if self._cache:
+                logger.debug(f"Loaded {len(self._cache)} cached annotations")
+
+    def _save(self) -> None:
+        """Save cache to disk with file locking and merge."""
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+        with FileLock(self._lock_file):
+            # Re-read to get any changes from other instances
+            disk_cache = self._read_from_disk()
+            # Merge: start with disk cache, apply our changes
+            merged = dict(disk_cache)
+            # Apply our current values (overwrites disk values)
+            merged.update(self._cache)
+            # Remove keys we explicitly deleted
+            for key in self._deleted_keys:
+                merged.pop(key, None)
+            self._write_to_disk(merged)
+            # Update in-memory state
+            self._cache = merged
+            self._deleted_keys.clear()
 
     def get(self, session_id: str, turn_number: int) -> str | None:
         """Get cached annotation for a turn."""
         key = annotation_key(session_id, turn_number)
-        with self._lock:
+        with self._thread_lock:
             return self._cache.get(key)
 
     def set(self, session_id: str, turn_number: int, annotation: str) -> None:
         """Store annotation for a turn."""
         key = annotation_key(session_id, turn_number)
-        with self._lock:
+        with self._thread_lock:
             if annotation:
                 self._cache[key] = annotation
+                self._deleted_keys.discard(key)
             elif key in self._cache:
                 del self._cache[key]
+                self._deleted_keys.add(key)
             self._save()
 
     def delete(self, session_id: str, turn_number: int) -> None:
         """Delete annotation for a turn."""
         key = annotation_key(session_id, turn_number)
-        with self._lock:
+        with self._thread_lock:
             if key in self._cache:
                 del self._cache[key]
-                self._save()
+            self._deleted_keys.add(key)
+            self._save()
 
     def __len__(self) -> int:
         """Return number of cached annotations."""
-        with self._lock:
+        with self._thread_lock:
             return len(self._cache)

--- a/uv.lock
+++ b/uv.lock
@@ -149,6 +149,7 @@ source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "click" },
+    { name = "filelock" },
     { name = "openai" },
     { name = "requests" },
     { name = "rich" },
@@ -159,6 +160,7 @@ dependencies = [
 requires-dist = [
     { name = "anthropic", specifier = ">=0.18" },
     { name = "click", specifier = ">=8.0" },
+    { name = "filelock", specifier = ">=3.0" },
     { name = "openai", specifier = ">=1.0" },
     { name = "requests", specifier = ">=2.28" },
     { name = "rich", specifier = ">=13.0" },
@@ -214,6 +216,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.20.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", size = 19485, upload-time = "2026-01-09T17:55:05.421Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", size = 16701, upload-time = "2026-01-09T17:55:04.334Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `filelock` dependency for cross-process file locking
- Refactor `SummaryCache` and `AnnotationCache` with read-before-write pattern
- Merges changes from other instances before saving to prevent data loss

## Test plan
- [x] Verified imports work: `uv run python -c "from claude_companion import cache; print('OK')"`
- [x] Tested concurrent access: 3 threads adding 10 entries each, all 30 entries preserved
- [x] Tested independent annotations from different instances merge correctly

Fixes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)