### PR TITLE
Add justfile with tag-latest command

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,7 @@
+# Tag a specific release version as "latest"
+# Usage: just tag-latest v0.8.0
+tag-latest release-ver:
+    git tag -d latest 2>/dev/null || true
+    git push origin :refs/tags/latest 2>/dev/null || true
+    git tag latest {{release-ver}}
+    git push origin latest


### PR DESCRIPTION
## Summary
- Adds a justfile with a `tag-latest` command for tagging release versions as "latest"
- Usage: `just tag-latest v0.8.0`

## Test plan
- [x] Run `just tag-latest <version>` to verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)