### PR TITLE
Fix TUI to start and watch even when no sessions exist

### DIFF
--- a/src/claude_companion/cli.py
+++ b/src/claude_companion/cli.py
@@ -36,9 +36,9 @@ def get_project_paths(global_mode: bool) -> list[Path]:
     if global_mode:
         # All project directories (those starting with "-")
         if not projects_dir.exists():
-            return [projects_dir]  # Watch the parent dir for new projects
+            return []
         return [p for p in projects_dir.iterdir()
-                if p.is_dir() and p.name.startswith("-")] or [projects_dir]
+                if p.is_dir() and p.name.startswith("-")]
     else:
         # Current directory only - return path even if it doesn't exist yet
         # The watcher will poll until sessions appear


### PR DESCRIPTION
## Summary
- Removes early exit when no Claude sessions are found
- TUI now starts immediately and watches for sessions to appear
- `get_project_paths()` returns expected paths even if they don't exist yet (watcher polls until sessions appear)

## Test plan
- [x] Run `claude-companion` in a directory with no Claude sessions - TUI should start and wait
- [x] Start a Claude session in the same directory - companion should detect and display it
- [ ] Test `--global` mode with no sessions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)