### PR TITLE
Improve tag-latest validation

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,7 +2,12 @@
 # Usage: just tag-latest v0.8.0
 tag-latest release-ver:
     git fetch --tags
-    git rev-parse --verify {{release-ver}} >/dev/null 2>&1 || (echo "Error: release ref '{{release-ver}}' not found. Did you fetch tags? Try: git fetch --tags" >&2; exit 1)
+    git rev-parse --verify {{release-ver}} >/dev/null 2>&1 || ( \
+        echo "Error: release ref '{{release-ver}}' not found after fetching tags." >&2; \
+        echo "Recent tags:" >&2; \
+        git tag --sort=-creatordate | head -n 10 >&2; \
+        exit 1 \
+    )
     git tag -d latest 2>/dev/null || true
     git push origin :refs/tags/latest 2>/dev/null || true
     git tag latest {{release-ver}}


### PR DESCRIPTION
## Summary
- fetch tags before retagging latest
- add clearer error when release ref is missing

## Testing
- not run (not needed for justfile change)