### PR TITLE
Make insight panel a persistent toggle instead of auto-pop

### DIFF
--- a/src/claude_companion/tui_textual.py
+++ b/src/claude_companion/tui_textual.py
@@ -2250,6 +2250,8 @@ class CompanionApp(App):
     def action_toggle_analysis_panel(self) -> None:
         """Toggle the insights panel on/off."""
         self._show_analysis_panel = not self._show_analysis_panel
+        if not self._show_analysis_panel:
+            self._reset_analysis_level()
         self._refresh_analysis_panel()
         label = "shown" if self._show_analysis_panel else "hidden"
         self._show_status(f"Insights panel {label}")


### PR DESCRIPTION
## Summary

- The analysis (insight) panel is now a **persistent toggle** instead of auto-popping based on whether the selected turn has analysis data
- Adds `I` keybinding to toggle the panel, with an empty state placeholder ("No analysis for this selection. Press A to analyze.")
- `A` (analyze), `[`/`]` (zoom) auto-open the panel; `Escape` closes it
- Navigating between turns keeps the panel visible, showing analysis or empty state

Closes #123

## Test plan

- [x] Navigate to a turn — panel does NOT auto-pop
- [x] Press `I` — panel appears with empty state message
- [x] Press `A` — analysis runs, panel auto-opens with results
- [x] Navigate to non-analyzed turn — panel stays visible, shows empty state
- [x] Navigate to analyzed turn — panel shows that turn's analysis
- [x] Press `I` — panel hides
- [x] Press `[`/`]` — panel auto-opens with zoom level change
- [x] Press `Escape` — panel closes
- [x] `T`/`P` overlay toggles still work independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)