### PR TITLE
Add span view filter for between-user-turns overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,23 +50,53 @@ The companion auto-detects your session. No hooks or configuration needed.
 
 ## Keybindings
 
+### Navigation
+
 | Key | Action |
 |-----|--------|
 | `j/k` | Navigate turns |
 | `g/G` | Jump to beginning/end |
-| `o` / `Space` | Expand/collapse turn |
-| `e/c` | Expand/collapse all |
 | `1-9` | Switch sessions |
+| `h/l` | Switch panels (manager expand mode) |
+
+### Display
+
+| Key | Action |
+|-----|--------|
+| `o` / `Space` / `Enter` | Expand/collapse turn or span |
+| `e/c` | Expand/collapse all |
+| `f` | Cycle filters (All, Spans, Tools, Read, Write, Edit, Bash) |
 | `s/S` | Toggle summaries / Summarize all |
-| `f` | Cycle filters |
-| `T/P` | Tasks / Plan view |
+
+### Views
+
+| Key | Action |
+|-----|--------|
+| `M` | Toggle manager view |
+| `T` | Toggle tasks view |
+| `P` | Toggle plan view |
+| `I` | Toggle insights (analysis) panel |
+
+### Analysis & Annotations
+
+| Key | Action |
+|-----|--------|
+| `A` | Analyze selected turn/span/session |
+| `[`/`]` | Zoom analysis level (turn / span / session) |
+| `n` | Annotate selected turn |
+| `a` | Toggle/clear alerts |
+
+### Other
+
+| Key | Action |
+|-----|--------|
+| `O` | Open PR in browser |
+| `x` | Export to Markdown |
 | `m` | Edit monitor instructions |
 | `?` | Ask about trace |
-| `x` | Export to Markdown |
 | `D` | Delete session |
+| `Esc` | Close panel / clear selection |
 | `q` | Quit |
-
-See all keybindings in the TUI status bar.
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,20 +29,50 @@ Betty auto-detects your session. No hooks or configuration needed.
 
 ## Keybindings
 
+### Navigation
+
 | Key | Action |
 |-----|--------|
 | `j/k` | Navigate turns |
 | `g/G` | Jump to beginning/end |
-| `o` / `Space` | Expand/collapse turn |
-| `e/c` | Expand/collapse all |
 | `1-9` | Switch sessions |
+| `h/l` | Switch panels (manager expand mode) |
+
+### Display
+
+| Key | Action |
+|-----|--------|
+| `o` / `Space` / `Enter` | Expand/collapse turn or span |
+| `e/c` | Expand/collapse all |
+| `f` | Cycle filters (All, Spans, Tools, Read, Write, Edit, Bash) |
 | `s/S` | Toggle summaries / Summarize all |
-| `f` | Cycle filters |
-| `T/P` | Tasks / Plan view |
+
+### Views
+
+| Key | Action |
+|-----|--------|
+| `M` | Toggle manager view |
+| `T` | Toggle tasks view |
+| `P` | Toggle plan view |
+| `I` | Toggle insights (analysis) panel |
+
+### Analysis & Annotations
+
+| Key | Action |
+|-----|--------|
+| `A` | Analyze selected turn/span/session |
+| `[`/`]` | Zoom analysis level (turn / span / session) |
+| `n` | Annotate selected turn |
+| `a` | Toggle/clear alerts |
+
+### Other
+
+| Key | Action |
+|-----|--------|
+| `O` | Open PR in browser |
+| `x` | Export to Markdown |
 | `m` | Edit monitor instructions |
 | `?` | Ask about trace |
-| `x` | Export to Markdown |
 | `D` | Delete session |
+| `Esc` | Close panel / clear selection |
 | `q` | Quit |
-
-See all keybindings in the TUI status bar.


### PR DESCRIPTION
## Summary

- Adds a **Spans** filter (cycled via `f`) that groups all turns by user message, collapsing assistant + tool responses under each user turn header — providing a table-of-contents style overview of a session
- New `SpanGroup` model and `SpanGroupWidget` with both rich and claude-code style rendering
- Full integration with navigation (`j/k`), expand/collapse (`space`/`e`/`c`), analysis (`A`/`[`/`]`), and annotations (`n`)
- Updates keybinding documentation in README.md and docs/index.md with all previously undocumented bindings

## Test plan

- [ ] `uv run betty` — press `f` to cycle to "Spans" filter
- [ ] Verify user turns appear as span headers with collapsed response summaries
- [ ] Press `space`/`enter` to expand a span — all response turns appear
- [ ] Press `space` again to collapse
- [ ] Press `e` to expand all, `c` to collapse all
- [ ] Navigate with `j`/`k` between spans
- [ ] Press `f` again to cycle to other filters — normal behavior preserved
- [ ] Test with both `--style rich` and `--style claude-code`
- [ ] Switch sessions — verify span expanded state resets

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)