### PR TITLE
Add customizable summarization style and prompts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,8 @@ pip install -e .
 # Run the companion
 betty                # Watch current directory's sessions
 betty --global       # Watch all projects
+betty --manager      # Start in manager view (all sessions)
+betty --worktree     # Watch git worktrees of current repo
 
 # Run with uv (no install needed)
 uv run betty
@@ -23,7 +25,23 @@ uv run betty
 betty config --show                    # Show current config
 betty config --llm-preset lm-studio    # Use LM Studio preset
 betty config --llm-preset ollama       # Use Ollama preset
+betty config --llm-preset anthropic    # Use Anthropic API
+betty config --llm-preset openai       # Use OpenAI API
 betty config --url URL --model MODEL   # Custom configuration
+
+# UI configuration
+betty config --style rich              # Emoji/box-based style
+betty config --style claude-code       # Minimal style matching Claude Code CLI
+betty config --collapse-tools          # Collapse consecutive tool turns
+betty config --manager-open-mode auto  # Manager mode: swap, expand, or auto
+
+# Summary style configuration
+betty config --summary-style brief         # Ultra-short, under 15 words
+betty config --summary-style detailed      # 2-3 sentences with reasoning
+betty config --summary-style technical     # File paths, function names, line numbers
+betty config --summary-style explanatory   # Focus on intent and reasoning
+betty config --summary-style default       # Reset to default 1-sentence style
+betty config --summary-prompt "Custom prompt text"  # Fully custom prompt
 
 # Analyzer configuration (for on-demand analysis)
 betty config --analyzer-budget N         # Set context budget in chars
@@ -31,7 +49,7 @@ betty config --analyzer-small-range N    # Max turns for small range
 betty config --analyzer-large-range N    # Min turns for large range
 
 # Test imports
-uv run python -c "from betty import tui, store, models; print('OK')"
+uv run python -c "from betty import tui_textual, store, models; print('OK')"
 ```
 
 ## Architecture
@@ -42,24 +60,29 @@ uv run python -c "from betty import tui, store, models; print('OK')"
 2. When a session file is discovered, `EventStore` creates a new `Session` and starts a `TranscriptWatcher`
 3. `TranscriptWatcher` (`watcher.py`) polls the transcript JSONL file for new entries
 4. New turns are parsed and added to the session, triggering TUI updates
+5. **PRDetector** (`github.py`) asynchronously detects GitHub PRs for each session's branch
 
 ### Key Components
 
+- **`tui_textual.py`** - Main Textual-based TUI: session detail view, manager view, keyboard input, CSS styling
 - **`store.py`** - Central `EventStore` class: thread-safe session/turn storage, coordinates watchers/alerts/summarizer/analyzer
 - **`project_watcher.py`** - `ProjectWatcher`: scans project directories for session files, notifies on new sessions
 - **`watcher.py`** - `TranscriptWatcher`: polls transcript file, parses JSONL entries into `Turn` objects
 - **`transcript.py`** - Parses `session.jsonl` files to load conversation history on session start
-- **`models.py`** - Data classes: `Turn` (conversation turn), `Session` (groups turns), `TaskState`
-- **`tui.py`** - Rich-based TUI: renders sessions, turns, handles keyboard input
+- **`models.py`** - Data classes: `Turn`, `Session`, `TaskState`, `ToolGroup`
+- **`github.py`** - `PRDetector`: async GitHub PR detection via `gh` CLI, caches by (project_dir, branch)
+- **`styles.py`** - UI style renderers: `RichStyle` (emoji/box-based) and `ClaudeCodeStyle` (minimal)
 - **`alerts.py`** - Pattern matching for dangerous operations (force push, rm -rf, etc.)
-- **`summarizer.py`** - Optional LLM summarization of assistant turns via OpenAI-compatible server
-- **`cache.py`** - Persistent disk cache for summaries (`~/.cache/betty/summaries.json`)
-- **`config.py`** - Configuration management for LLM server settings (supports env vars, config file, defaults)
-- **`export.py`** - Export session data to Markdown or JSON formats
-- **`mock_session.py`** - Mock session generator for development: creates realistic Claude Code session files for testing and cloud-based development without Claude Code
+- **`summarizer.py`** - Optional LLM summarization of assistant turns via litellm, with configurable style presets
 - **`analyzer.py`** - On-demand LLM analysis: structured analysis (summary, critique, sentiment), multi-level analysis (turn/span/session), multi-source goal extraction, cost tracking
+- **`cache.py`** - Persistent disk cache for summaries and annotations (`~/.cache/betty/`)
+- **`config.py`** - Configuration management (env vars, `~/.betty/config.toml`, defaults)
+- **`export.py`** - Export session data to Markdown or JSON formats
 - **`pricing.py`** - Model pricing database and cost estimation utilities for token usage tracking
+- **`mock_session.py`** - Mock session generator for development/testing
+- **`utils.py`** - Utility functions
 - **`cli.py`** - Click-based CLI with commands: `config`, `mock`
+- **`tui.py`** - Legacy Rich-based TUI (superseded by `tui_textual.py`)
 
 ### Session Discovery
 
@@ -69,19 +92,29 @@ By default, only sessions for the current directory are shown. Use `--global` to
 
 ### Threading Model
 
-- Main thread: TUI rendering loop
+- Main thread: Textual TUI event loop
 - Project watcher thread: Directory scanning (daemon)
 - Watcher threads: Transcript file polling (daemon, one per session)
+- Plan file watcher threads: Monitor PLAN.md / .claude/plan.md per session (daemon)
 - Summarizer threads: ThreadPoolExecutor for async LLM calls (2 workers)
 - Analyzer threads: ThreadPoolExecutor for async LLM analysis (1 worker)
+- PR detection threads: Background threads for `gh` CLI calls (spawned by PRDetector)
 - All shared state in `EventStore` protected by `threading.Lock`
+
+### Manager View
+
+The manager view (`M` key) displays all sessions grouped by project, with GitHub PR info on group headers. Sessions show stats (turns, tools, model, branch). Two layout modes:
+- **Swap**: Manager replaces the detail view
+- **Expand**: Side-by-side manager (left) + detail pane (right), navigable with `h`/`l`
+- **Auto**: Chooses based on terminal width
 
 ### Optional Features
 
-**LLM Summarization**: Assistant turns can be summarized using any OpenAI-compatible local LLM server. Supported options:
+**LLM Integration**: LLM calls go through litellm, supporting any compatible provider. Presets available:
 - **LM Studio** (recommended for Mac): `http://localhost:1234/v1`
 - **Ollama**: `http://localhost:11434/v1`
 - **vLLM**: `http://localhost:8008/v1` (default)
+- **OpenAI**, **Anthropic**, **OpenRouter**: Cloud API providers
 
 Configuration priority:
 1. Environment variables: `BETTY_LLM_API_BASE`, `BETTY_LLM_MODEL`
@@ -90,6 +123,14 @@ Configuration priority:
 
 Use `betty config` to set up your LLM server. Summaries are cached to disk and persist across sessions. The feature gracefully degrades if the server is unavailable.
 
-**On-Demand Analysis**: Turns, spans, and sessions can be analyzed on-demand using any OpenAI-compatible local LLM server. The analyzer provides structured analysis (summary, critique, sentiment) with multi-source goal extraction (first user message, GitHub issues, plan files, active tasks). Triggered via `A` keybinding in the TUI, with `[`/`]` to zoom between turn, span, and session levels. Analysis results are cached to disk and persist across sessions. The feature gracefully degrades if the server is unavailable.
+**Summarization Styles**: Summaries can be customized with preset styles (`default`, `brief`, `detailed`, `technical`, `explanatory`) or a fully custom prompt. Set via `betty config --summary-style <style>` or `betty config --summary-prompt "..."`. Environment variables `BETTY_SUMMARY_STYLE` and `BETTY_SUMMARY_PROMPT` override the config file. Changing styles automatically invalidates the summary cache.
+
+**On-Demand Analysis**: Turns, spans, and sessions can be analyzed on-demand. The analyzer provides structured analysis (summary, critique, sentiment) with multi-source goal extraction (first user message, GitHub issues, plan files, active tasks). Triggered via `A` keybinding in the TUI, with `[`/`]` to zoom between turn, span, and session levels. Toggle analysis panel with `I`. Analysis results are cached to disk.
+
+**GitHub PR Integration**: Automatic PR detection for each session's git branch using the `gh` CLI. PR info (number, title, URL, state) is displayed on manager view headers and session cards. Press `O` to open the PR in a browser.
+
+**Plan File Monitoring**: Auto-detects PLAN.md or .claude/plan.md in the project directory. Real-time updates via dedicated watcher threads. Toggle display with `P`.
+
+**Tool Grouping**: Consecutive tool turns are collapsed into `ToolGroup` objects for compact display. Toggle with `--collapse-tools` config or CLI flag.
 
 **Export**: Sessions can be exported to Markdown or JSON via the `export.py` module (used by TUI keyboard shortcuts).

--- a/tests/test_summarizer_config.py
+++ b/tests/test_summarizer_config.py
@@ -1,0 +1,207 @@
+"""Tests for customizable summarization style and prompts."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from betty.config import Config, LLMConfig, SummaryConfig, AnalyzerConfig, load_config, save_config
+from betty.summarizer import (
+    SUMMARY_STYLES,
+    SYSTEM_PROMPT,
+    TOOL_SYSTEM_PROMPT,
+    VALID_SUMMARY_STYLES,
+    Summarizer,
+    _prompt_fingerprint,
+    get_summary_prompts,
+)
+
+
+class TestGetSummaryPrompts:
+    """Tests for get_summary_prompts helper."""
+
+    def test_default_style(self):
+        system, tool = get_summary_prompts("default")
+        assert system == SYSTEM_PROMPT
+        assert tool == TOOL_SYSTEM_PROMPT
+
+    def test_brief_style(self):
+        system, tool = get_summary_prompts("brief")
+        assert "under 15 words" in system
+        assert "under 15 words" in tool
+        assert system != SYSTEM_PROMPT
+
+    def test_detailed_style(self):
+        system, tool = get_summary_prompts("detailed")
+        assert "2-3 sentences" in system
+        assert "2-3 sentences" in tool
+
+    def test_technical_style(self):
+        system, tool = get_summary_prompts("technical")
+        assert "file paths" in system.lower() or "file path" in system.lower()
+        assert "exit codes" in tool.lower() or "exit code" in tool.lower()
+
+    def test_explanatory_style(self):
+        system, tool = get_summary_prompts("explanatory")
+        assert "WHY" in system
+        assert "WHY" in tool
+
+    def test_custom_style_with_prompt(self):
+        custom = "Summarize in haiku form"
+        system, tool = get_summary_prompts("custom", custom)
+        assert system == custom
+        assert tool == custom
+
+    def test_custom_style_without_prompt_falls_back(self):
+        system, tool = get_summary_prompts("custom", None)
+        # Falls back to default when custom prompt is None
+        assert system == SYSTEM_PROMPT
+        assert tool == TOOL_SYSTEM_PROMPT
+
+    def test_unknown_style_falls_back(self):
+        system, tool = get_summary_prompts("nonexistent")
+        assert system == SYSTEM_PROMPT
+        assert tool == TOOL_SYSTEM_PROMPT
+
+    def test_all_styles_in_dict(self):
+        expected = {"default", "brief", "detailed", "technical", "explanatory"}
+        assert expected == set(SUMMARY_STYLES.keys())
+
+    def test_valid_styles_includes_custom(self):
+        assert "custom" in VALID_SUMMARY_STYLES
+        for style in SUMMARY_STYLES:
+            assert style in VALID_SUMMARY_STYLES
+
+
+class TestSummarizerInstancePrompts:
+    """Tests for Summarizer storing correct prompts per style."""
+
+    def test_default_prompts(self):
+        s = Summarizer(model="test-model", summary_style="default")
+        assert s.system_prompt == SYSTEM_PROMPT
+        assert s.tool_system_prompt == TOOL_SYSTEM_PROMPT
+
+    def test_brief_prompts(self):
+        s = Summarizer(model="test-model", summary_style="brief")
+        assert "under 15 words" in s.system_prompt
+        assert "under 15 words" in s.tool_system_prompt
+
+    def test_custom_prompts(self):
+        custom = "Be a pirate"
+        s = Summarizer(model="test-model", summary_style="custom", custom_summary_prompt=custom)
+        assert s.system_prompt == custom
+        assert s.tool_system_prompt == custom
+
+    def test_no_style_arg_uses_default(self):
+        s = Summarizer(model="test-model")
+        assert s.system_prompt == SYSTEM_PROMPT
+        assert s.tool_system_prompt == TOOL_SYSTEM_PROMPT
+
+
+class TestCacheFingerprint:
+    """Tests that cache fingerprints vary by style."""
+
+    def test_different_styles_produce_different_fingerprints(self):
+        model = "test-model"
+        default_sys, _ = get_summary_prompts("default")
+        brief_sys, _ = get_summary_prompts("brief")
+        fp_default = _prompt_fingerprint(model, default_sys)
+        fp_brief = _prompt_fingerprint(model, brief_sys)
+        assert fp_default != fp_brief
+
+    def test_same_style_produces_same_fingerprint(self):
+        model = "test-model"
+        sys1, _ = get_summary_prompts("detailed")
+        sys2, _ = get_summary_prompts("detailed")
+        assert _prompt_fingerprint(model, sys1) == _prompt_fingerprint(model, sys2)
+
+    def test_custom_prompt_produces_unique_fingerprint(self):
+        model = "test-model"
+        default_sys, _ = get_summary_prompts("default")
+        custom_sys, _ = get_summary_prompts("custom", "my custom prompt")
+        fp_default = _prompt_fingerprint(model, default_sys)
+        fp_custom = _prompt_fingerprint(model, custom_sys)
+        assert fp_default != fp_custom
+
+
+class TestSummaryConfigRoundTrip:
+    """Tests for SummaryConfig persistence in TOML."""
+
+    def test_default_config_not_saved(self):
+        """Default SummaryConfig should not add a summary section to TOML."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = Path(tmpdir) / "config.toml"
+            config = Config(
+                llm=LLMConfig(model="test-model"),
+                summary=SummaryConfig(),
+            )
+            with patch("betty.config.CONFIG_FILE", config_file), \
+                 patch("betty.config.CONFIG_DIR", Path(tmpdir)):
+                save_config(config)
+
+                content = config_file.read_text()
+                assert "summary" not in content
+
+    def test_non_default_style_saved(self):
+        """Non-default summary style should be persisted."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = Path(tmpdir) / "config.toml"
+            config = Config(
+                llm=LLMConfig(model="test-model"),
+                summary=SummaryConfig(style="brief"),
+            )
+            with patch("betty.config.CONFIG_FILE", config_file), \
+                 patch("betty.config.CONFIG_DIR", Path(tmpdir)):
+                save_config(config)
+                loaded = load_config()
+
+            assert loaded.summary.style == "brief"
+
+    def test_custom_prompt_saved(self):
+        """Custom prompt should be persisted."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = Path(tmpdir) / "config.toml"
+            config = Config(
+                llm=LLMConfig(model="test-model"),
+                summary=SummaryConfig(style="custom", custom_prompt="Summarize like a pirate"),
+            )
+            with patch("betty.config.CONFIG_FILE", config_file), \
+                 patch("betty.config.CONFIG_DIR", Path(tmpdir)):
+                save_config(config)
+                loaded = load_config()
+
+            assert loaded.summary.style == "custom"
+            assert loaded.summary.custom_prompt == "Summarize like a pirate"
+
+    def test_env_var_overrides_style(self):
+        """BETTY_SUMMARY_STYLE env var should override config file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = Path(tmpdir) / "config.toml"
+            config = Config(
+                llm=LLMConfig(model="test-model"),
+                summary=SummaryConfig(style="brief"),
+            )
+            with patch("betty.config.CONFIG_FILE", config_file), \
+                 patch("betty.config.CONFIG_DIR", Path(tmpdir)), \
+                 patch.dict("os.environ", {"BETTY_SUMMARY_STYLE": "technical"}):
+                save_config(config)
+                loaded = load_config()
+
+            assert loaded.summary.style == "technical"
+
+    def test_env_var_overrides_prompt(self):
+        """BETTY_SUMMARY_PROMPT env var should override and set style to custom."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = Path(tmpdir) / "config.toml"
+            config = Config(
+                llm=LLMConfig(model="test-model"),
+            )
+            with patch("betty.config.CONFIG_FILE", config_file), \
+                 patch("betty.config.CONFIG_DIR", Path(tmpdir)), \
+                 patch.dict("os.environ", {"BETTY_SUMMARY_PROMPT": "Be concise"}):
+                save_config(config)
+                loaded = load_config()
+
+            assert loaded.summary.style == "custom"
+            assert loaded.summary.custom_prompt == "Be concise"


### PR DESCRIPTION
## Summary
- Adds preset summarization styles (`brief`, `detailed`, `technical`, `explanatory`) and custom prompt support, configurable via `betty config --summary-style` / `--summary-prompt`, config file (`~/.betty/config.toml`), and environment variables (`BETTY_SUMMARY_STYLE`, `BETTY_SUMMARY_PROMPT`)
- Follows the existing `AnalyzerConfig` pattern: new `SummaryConfig` dataclass in `config.py`, prompt resolution in `summarizer.py`, instance-level prompts passed through `store.py`
- Cache invalidation is automatic — changing styles produces different fingerprints so stale summaries are never reused

Closes #42

## Test plan
- [x] 22 new tests in `tests/test_summarizer_config.py` covering all styles, custom prompts, cache fingerprint variation, and config round-trip (TOML + env vars)
- [x] Full test suite passes (213 tests)
- [ ] Manual: `betty config --summary-style brief && betty config --show` shows "Style: brief"
- [ ] Manual: `betty config --summary-prompt "Summarize in haiku form" && betty config --show` shows "Style: custom" with prompt preview
- [ ] Manual: `BETTY_SUMMARY_STYLE=technical betty config --show` shows env var override

🤖 Generated with [Claude Code](https://claude.com/claude-code)