### PR TITLE
Fix plan view showing stale content (#79)

### DIFF
--- a/src/betty/utils.py
+++ b/src/betty/utils.py
@@ -59,38 +59,13 @@ def decode_project_path(encoded_path: str) -> str:
     return current if current else "/" + "/".join(parts)
 
 
-def find_plan_file(project_dir: str) -> str | None:
-    """Find plan file in project directory.
-
-    Searches in order of preference:
-    1. PLAN.md
-    2. .claude/plan.md
-    3. .claude/PLAN.md
-    4. plan.md
+def is_claude_plan_file(file_path: str) -> bool:
+    """Check if a file path is a Claude Code plan file in ~/.claude/plans/.
 
     Args:
-        project_dir: Absolute path to project directory
+        file_path: File path string to check
 
     Returns:
-        Absolute path to plan file if found, None otherwise
+        True if the path matches ~/.claude/plans/*.md
     """
-    if not project_dir:
-        return None
-
-    base = Path(project_dir)
-    if not base.exists() or not base.is_dir():
-        return None
-
-    # Search in priority order
-    candidates = [
-        base / "PLAN.md",
-        base / ".claude" / "plan.md",
-        base / ".claude" / "PLAN.md",
-        base / "plan.md",
-    ]
-
-    for path in candidates:
-        if path.exists() and path.is_file():
-            return str(path)
-
-    return None
+    return "/.claude/plans/" in file_path and file_path.endswith(".md")

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -83,7 +83,7 @@ class TestTranscriptCommandMerge:
         ]
         self._write_jsonl(path, entries)
 
-        turns, _ = parse_transcript(path)
+        turns, _, _ = parse_transcript(path)
         assert len(turns) == 1
         assert turns[0].role == "user"
         assert turns[0].content_full.startswith("/agent-review\n\n")
@@ -100,7 +100,7 @@ class TestTranscriptCommandMerge:
         ]
         self._write_jsonl(path, entries)
 
-        turns, _ = parse_transcript(path)
+        turns, _, _ = parse_transcript(path)
         # No command name → first entry is a normal turn, not merged
         assert len(turns) == 2
 
@@ -118,7 +118,7 @@ class TestTranscriptCommandMerge:
         ]
         self._write_jsonl(path, entries)
 
-        turns, _ = parse_transcript(path)
+        turns, _, _ = parse_transcript(path)
         assert len(turns) == 1
         assert turns[0].role == "assistant"
 
@@ -311,7 +311,7 @@ class TestParseTranscript:
         ]
         self._write_jsonl(path, entries)
 
-        turns, pos = parse_transcript(path)
+        turns, pos, _ = parse_transcript(path)
         assert len(turns) == 4
         assert turns[0].role == "user"
         assert turns[1].role == "assistant"
@@ -332,7 +332,7 @@ class TestParseTranscript:
         ]
         self._write_jsonl(path, entries)
 
-        turns, pos = parse_transcript(path)
+        turns, pos, _ = parse_transcript(path)
         assert len(turns) == 2
         assert turns[0].role == "user"
         assert turns[1].role == "assistant"
@@ -350,7 +350,7 @@ class TestParseTranscript:
         ]
         self._write_jsonl(path, entries)
 
-        turns, pos = parse_transcript(path)
+        turns, pos, _ = parse_transcript(path)
         assert len(turns) == 2
         assert turns[0].role == "user"
         assert turns[0].content_full == "Init issue context"
@@ -364,7 +364,7 @@ class TestParseTranscript:
             f.write("not valid json\n")
             f.write(json.dumps(_user_entry("After")) + "\n")
 
-        turns, pos = parse_transcript(path)
+        turns, pos, _ = parse_transcript(path)
         assert len(turns) == 2
         assert turns[0].content_full == "Before"
         assert turns[1].content_full == "After"
@@ -373,7 +373,7 @@ class TestParseTranscript:
         with tempfile.NamedTemporaryFile(suffix=".jsonl", mode="w", delete=False) as f:
             path = Path(f.name)
 
-        turns, pos = parse_transcript(path)
+        turns, pos, _ = parse_transcript(path)
         assert turns == []
         assert pos == 0
 


### PR DESCRIPTION
## Summary

- Claude Code writes plans to `~/.claude/plans/<name>.md`, not `PLAN.md` in the project root. The old `PlanFileWatcher` polled for `PLAN.md` and showed stale content.
- Replaced `PlanFileWatcher` with transcript-based plan detection: extracts plan content from `Write`, `Edit`, and `ExitPlanMode` tool calls in the session transcript stream.
- Historical plans are loaded from transcript on session start, and real-time updates are captured as they happen.

## Test plan

- [ ] Run `uv run betty`, open a session, enter plan mode, write a plan — press `P` to verify plan content appears
- [ ] Edit the plan in Claude Code — verify Betty updates in real-time
- [ ] Exit plan mode — verify plan view shows the final plan
- [ ] Restart Betty and open the same session — verify historical plan loads from transcript
- [ ] Verify stale `PLAN.md` files in the project root are no longer shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)