### PR TITLE
Fix parse_transcript unpacking after plan info was added

### DIFF
--- a/src/betty/store.py
+++ b/src/betty/store.py
@@ -970,7 +970,7 @@ class EventStore:
             return 0
 
         # Parse transcript - use as source of truth for all turns
-        transcript_turns, file_position = parse_transcript(path)
+        transcript_turns, file_position, plan_info = parse_transcript(path)
 
         if transcript_turns:
             # Replace session turns with transcript (source of truth)
@@ -980,6 +980,8 @@ class EventStore:
                 if session_id not in self._sessions:
                     return file_position
                 session.turns = transcript_turns
+                if plan_info:
+                    session.plan_content = plan_info[0]
 
                 # Process task operations from historical turns
                 for turn in transcript_turns:


### PR DESCRIPTION
## Summary
- `parse_transcript` was updated to return a 3-tuple `(turns, file_position, plan_info)` but `_load_transcript_history` in `store.py` was still unpacking only 2 values, causing a `ValueError` on startup
- Unpack the third value and apply `plan_info` to the session's `plan_content`

## Test plan
- [x] `uv run betty` launches without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)