### PR TITLE
Fix NameError: remove stale PlanFileWatcher reference

### DIFF
--- a/src/betty/store.py
+++ b/src/betty/store.py
@@ -171,15 +171,6 @@ class EventStore:
                             session.branch = branch
                     self._pr_detector.detect_async(project_dir, branch)
 
-            if project_dir:
-                plan_watcher = PlanFileWatcher(
-                    project_dir,
-                    lambda content, path, sid=session_id: self._on_plan_update(sid, content, path, source="file")
-                )
-                plan_watcher.start()
-                with self._lock:
-                    self._plan_watchers[session_id] = plan_watcher
-
 
     @staticmethod
     def _detect_git_branch(project_dir: str) -> str | None:


### PR DESCRIPTION
## Summary
- Commit a6df3ab (summarization styles) reintroduced `PlanFileWatcher` code that was removed in bf1a2d1 (plan fix), likely due to a rebase conflict
- `PlanFileWatcher` class no longer exists — plan detection now works via the transcript stream
- This caused a `NameError` crash on every startup: `NameError: name 'PlanFileWatcher' is not defined`

## Test plan
- [x] `uv run python -c "from betty import store; print('OK')"` passes
- [ ] `uv run betty` starts without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)