### PR TITLE
Add Betty Agent documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ The companion auto-detects your session. No hooks or configuration needed.
 | `n` | Annotate selected turn |
 | `a` | Toggle/clear alerts |
 
+### Agent
+
+| Key | Action |
+|-----|--------|
+| `B` | Toggle agent panel (closed / full / compact) |
+| `?` | Ask Betty a question about the session |
+
 ### Other
 
 | Key | Action |
@@ -93,10 +100,46 @@ The companion auto-detects your session. No hooks or configuration needed.
 | `O` | Open PR in browser |
 | `x` | Export to Markdown |
 | `m` | Edit monitor instructions |
-| `?` | Ask about trace |
 | `D` | Delete session |
 | `Esc` | Close panel / clear selection |
 | `q` | Quit |
+
+## Betty Agent
+
+Betty Agent is a continuous session observer that tracks what Claude Code is doing and flags problems in real time. It combines heuristic detectors with optional LLM-powered narrative and drift detection.
+
+### Enable
+
+```bash
+betty config --agent
+```
+
+Or set the environment variable `BETTY_AGENT_ENABLED=true`.
+
+### What it does
+
+- **Goal tracking** — extracts the session goal and current objective, updating as the user gives new instructions
+- **Progress assessment** — classifies sessions as `on_track`, `stalled`, or `spinning` using error rates, retry patterns, and tool diversity
+- **Error spike detection** — warns when error rate exceeds 40% in recent tool calls
+- **Retry loop detection** — flags when the same tool is called 3+ times consecutively
+- **Stall detection** — notices gaps of 2+ minutes between turns
+- **File change tracking** — logs Read/Write/Edit operations with line counts
+- **Milestones** — marks every 10th tool call and 5th user message
+- **LLM narrative** (optional) — generates a 2-3 sentence situation report describing current activity
+- **Goal drift detection** (optional) — compares recent activity against the session goal and warns if the assistant has gone off track
+- **Ask Betty** — press `?` to ask a natural-language question about the session; Betty answers citing turn numbers and file paths
+
+### Configuration
+
+The agent uses your existing LLM configuration (set via `betty config`). LLM features (narrative, drift detection, goal determination, Ask Betty) require a configured LLM provider. Heuristic detectors work without one.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `enabled` | `false` | Enable the agent (opt-in) |
+| `update_interval` | `5` | Minimum turns between LLM updates |
+| `max_observations` | `50` | Max observations kept per session |
+
+Observations and reports are cached to disk (`~/.cache/betty/`) and persist across restarts.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Add Agent keybindings section (`B` to toggle panel, `?` to Ask Betty)
- Add Betty Agent section documenting all heuristic detectors, LLM features, and configuration
- Move `?` keybinding from "Other" to the new "Agent" section

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)