### PR TITLE
Add Cursor CLI code review workflow

### DIFF
--- a/.github/workflows/cursor-code-review.yml
+++ b/.github/workflows/cursor-code-review.yml
@@ -114,13 +114,12 @@ jobs:
               🤖 *Reviewed by Cursor Agent (gpt-5.3-codex)*
 
           Submission:
-          - EVERY review submission MUST have a non-empty body with the signature appended. Never submit a review with an empty body.
+          - ALWAYS submit a comment or review. Never silently skip submission.
+          - EVERY submission MUST have a non-empty body with the signature appended.
           - If there are NO new issues to report:
-            - Check if a prior "no issues" summary comment already exists (e.g., "✅ no issues", "No issues found", "LGTM").
-            - If one exists, do NOT submit another. Skip submission entirely.
-            - If none exists, submit a single top-level comment (via gh pr comment) with a brief "no new issues" message and the signature.
+            - Submit a single top-level comment via: gh pr comment ${{ github.event.pull_request.number }} --body "BODY_HERE"
+            - The comment should briefly state no new issues were found in the latest changes and include the signature.
           - If there ARE issues to report:
-            - If a prior "no issues" comment exists, delete/minimize/mark it as superseded first.
             - Submit ONE review via the GitHub Reviews API containing inline comments and a concise summary body with the signature.
             - Build a JSON array of comments like: [{ "path": "<file>", "position": <diff_position>, "body": "..." }]
             - Submit via: gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews -f event=COMMENT -f body="$SUMMARY" -f comments='\''[$COMMENTS_JSON]'\''


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow (`.github/workflows/cursor-code-review.yml`) that uses the Cursor CLI agent to perform automated PR code reviews
- Runs alongside the existing Claude Code review workflow
- Uses `gpt-5.3-codex` model, posts inline comments via the GitHub Reviews API, and supports optional blocking reviews via `BLOCKING_REVIEW` repo variable
- Keeps WIP commit skip logic and draft PR filtering

## Test plan
- [x] Add `CURSOR_API_KEY` repo secret
- [x] Push a commit to this PR to trigger both review workflows
- [x] Verify Cursor review posts inline comments correctly
- [ ] Test WIP skip by pushing a `[WIP]`-prefixed commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)