### PR TITLE
Document betty config --agent in --help and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,11 @@ betty config --summary-style explanatory   # Focus on intent and reasoning
 betty config --summary-style default       # Reset to default 1-sentence style
 betty config --summary-prompt "Custom prompt text"  # Fully custom prompt
 
+# Agent configuration (continuous session observer)
+betty config --agent                     # Enable Betty Agent
+betty config --no-agent                  # Disable Betty Agent
+# Alternatively: BETTY_AGENT_ENABLED=true betty
+
 # Analyzer configuration (for on-demand analysis)
 betty config --analyzer-budget N         # Set context budget in chars
 betty config --analyzer-small-range N    # Max turns for small range

--- a/src/betty/cli.py
+++ b/src/betty/cli.py
@@ -247,6 +247,7 @@ def config(style: str | None, url: str | None, model: str | None, preset: str | 
       betty config --llm-preset lm-studio     # Use LM Studio
       betty config --collapse-tools           # Enable tool collapsing
       betty config --debug-logging            # Enable debug logging
+      betty config --agent                    # Enable Betty Agent (continuous observer)
       betty config --show                     # Show current config
     """
     if show:


### PR DESCRIPTION
Fixes #154.

## Summary

- Added `betty config --agent` to the examples list in `betty config --help`
- Added an "Agent configuration" section to CLAUDE.md's development commands, including `--agent`, `--no-agent`, and the `BETTY_AGENT_ENABLED=true` env var alternative

## Test plan

- [ ] Run `betty config --help` and confirm the agent example appears in the examples block
- [ ] Check CLAUDE.md and confirm the agent configuration section is present with all three ways to enable/disable the agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)