### PR TITLE
Rename PyPI package to betty-cli and add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # needed for hatch-vcs to derive version from tags
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Build package
+        run: uv build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # required for OIDC trusted publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ curl -fsSL https://betty4.sh/install.sh | bash
 Or directly with uv / pip:
 
 ```bash
-uvx betty              # run without installing
-uv tool install betty  # install permanently
-pip install betty      # with pip
+uvx betty-cli              # run without installing
+uv tool install betty-cli  # install permanently
+pip install betty-cli      # with pip
 ```
 
 ## Use

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "betty"
+name = "betty-cli"
 dynamic = ["version"]
 description = "A CLI supervisor for Claude Code sessions"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Renames the PyPI package from `betty` to `betty-cli` (the name `betty` is already taken on PyPI)
- Updates `README.md` install commands to use `betty-cli`
- Adds `.github/workflows/publish.yml` to publish automatically on GitHub Release via OIDC trusted publishing (no API token needed)

The `betty` CLI command is unchanged — users still run `betty` after installing.

## Next steps after merge

1. Register a trusted publisher on PyPI: project name `betty-cli`, workflow `publish.yml`, environment `pypi`
2. Create a `pypi` environment in GitHub repo Settings → Environments
3. Create a GitHub Release from a version tag to trigger the publish workflow

Closes #118
Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)