### PR TITLE
Fix install.sh and uvx command for betty-cli package rename

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Copy install.sh into docs
+        run: cp install.sh docs/install.sh
       - uses: actions/configure-pages@v5
       - uses: actions/jekyll-build-pages@v1
         with:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ curl -fsSL https://betty4.sh/install.sh | bash
 Or directly with uv / pip:
 
 ```bash
-uvx betty-cli              # run without installing
+uvx --from betty-cli betty  # run without installing
 uv tool install betty-cli  # install permanently
 pip install betty-cli      # with pip
 ```

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@
 set -euo pipefail
 
 # ── Config ────────────────────────────────────────────────────────────
-PACKAGE_NAME="betty"
+PACKAGE_NAME="betty-cli"
 GITHUB_REPO="ai-companion/betty"
 BIN_DIR="${HOME}/.local/bin"
 


### PR DESCRIPTION
## Summary

Follow-up to #158 (betty → betty-cli rename):

- **`install.sh`**: update `PACKAGE_NAME` from `betty` to `betty-cli` so PyPI installs use the correct package name
- **`pages.yml`**: copy `install.sh` into `docs/` before Jekyll build, so `https://betty4.sh/install.sh` is actually served (it was 404ing because the file wasn't in `docs/`)
- **`README.md`**: fix uvx one-liner to `uvx --from betty-cli betty` — required when the package name and command name differ

🤖 Generated with [Claude Code](https://claude.com/claude-code)