### PR TITLE
Fix uvx command and PyPI link for betty-cli rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Or directly with uv / pip:
 
 ```bash
 uvx --from betty-cli betty  # run without installing
-uv tool install betty-cli  # install permanently
-pip install betty-cli      # with pip
+uv tool install betty-cli   # install permanently
+pip install betty-cli       # with pip
 ```
 
 ## Use

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -22,13 +22,13 @@
           <code>curl -fsSL https://betty4.sh/install.sh | bash</code>
         </div>
         <span class="hero-install-or">or</span>
-        <div class="hero-install" onclick="navigator.clipboard.writeText('uvx betty');this.classList.add('copied');setTimeout(()=>this.classList.remove('copied'),1500)" title="Click to copy">
-          <code>uvx betty</code>
+        <div class="hero-install" onclick="navigator.clipboard.writeText('uvx --from betty-cli betty');this.classList.add('copied');setTimeout(()=>this.classList.remove('copied'),1500)" title="Click to copy">
+          <code>uvx --from betty-cli betty</code>
         </div>
       </div>
       <div class="hero-links">
         <a href="https://github.com/ai-companion/betty" class="btn btn-primary">GitHub</a>
-        <a href="https://pypi.org/project/betty/" class="btn btn-secondary">PyPI</a>
+        <a href="https://pypi.org/project/betty-cli/" class="btn btn-secondary">PyPI</a>
       </div>
     </div>
   </header>

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,20 @@
 layout: default
 ---
 
+## Install
+
+```bash
+curl -fsSL https://betty4.sh/install.sh | bash
+```
+
+Or directly with uv / pip:
+
+```bash
+uvx --from betty-cli betty  # run without installing
+uv tool install betty-cli   # install permanently
+pip install betty-cli       # with pip
+```
+
 ## Quick Start (for the Shannons)
 
 ```bash


### PR DESCRIPTION
## Summary

Follow-up cleanup after the betty → betty-cli rename:

- **`docs/_layouts/default.html`**: fix hardcoded `uvx betty` in the hero install button to `uvx --from betty-cli betty`; fix PyPI link to point to `betty-cli`
- **`docs/index.md`**: add Install section with correct install commands (was missing entirely)
- **`README.md`**: fix off-by-one space in comment alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)