### PR TITLE
feat: tmux-based session discovery backend

### DIFF
--- a/src/betty/cli.py
+++ b/src/betty/cli.py
@@ -248,15 +248,19 @@ def run_companion(global_mode: bool = False, worktree_mode: bool = False, manage
 @click.option("--port", "-p", type=int, default=5557, help="Port to listen on (default: 5557)")
 @click.option("--host", default="127.0.0.1", help="Host to bind to (default: 127.0.0.1)")
 @click.option("--global", "-g", "global_mode", is_flag=True, help="Watch all projects")
-def server_cmd(port: int, host: str, global_mode: bool) -> None:
+@click.option("--backend", type=click.Choice(["file", "tmux"]), default="file", help="Session discovery backend (default: file)")
+@click.option("--tmux-socket", default=None, help="Tmux socket name (for --backend tmux)")
+def server_cmd(port: int, host: str, global_mode: bool, backend: str, tmux_socket: str | None) -> None:
     """Start the Betty API server.
 
     Exposes session data via a REST API so remote TUI clients can connect.
 
     Examples:
-      betty server                  # Start on default port 5557
-      betty server --port 8080      # Custom port
-      betty server --global         # Watch all projects
+      betty server                          # Start on default port 5557
+      betty server --port 8080              # Custom port
+      betty server --global                 # Watch all projects
+      betty server --backend tmux           # Discover sessions from tmux panes
+      betty server --backend tmux --tmux-socket main  # Custom tmux socket
     """
     from .server import run_server
 
@@ -274,6 +278,8 @@ def server_cmd(port: int, host: str, global_mode: bool) -> None:
         host=host,
         global_mode=global_mode,
         projects_dir=projects_dir if global_mode else None,
+        backend=backend,
+        tmux_socket=tmux_socket,
     )
 
 

--- a/src/betty/server.py
+++ b/src/betty/server.py
@@ -257,6 +257,8 @@ def run_server(
     host: str = "127.0.0.1",
     global_mode: bool = False,
     projects_dir: Path | None = None,
+    backend: str = "file",
+    tmux_socket: str | None = None,
 ) -> None:
     """Start the Betty API server.
 
@@ -268,14 +270,19 @@ def run_server(
         host: Host to bind to.
         global_mode: Watch all projects.
         projects_dir: Parent projects directory (for global mode).
+        backend: Discovery backend: ``"file"`` (default) or ``"tmux"``.
+        tmux_socket: Tmux socket name for the tmux backend.
     """
     store = EventStore(enable_notifications=False)
-    store.start_watching(
-        project_paths,
-        max_sessions=None,
-        projects_dir=projects_dir,
-        global_mode=global_mode,
-    )
+    if backend == "tmux":
+        store.start_watching_tmux(socket=tmux_socket)
+    else:
+        store.start_watching(
+            project_paths,
+            max_sessions=None,
+            projects_dir=projects_dir,
+            global_mode=global_mode,
+        )
 
     handler = _make_handler(store)
     server = ThreadingHTTPServer((host, port), handler)

--- a/src/betty/server.py
+++ b/src/betty/server.py
@@ -276,13 +276,15 @@ def run_server(
     store = EventStore(enable_notifications=False)
     if backend == "tmux":
         store.start_watching_tmux(socket=tmux_socket)
-    else:
+    elif backend == "file":
         store.start_watching(
             project_paths,
             max_sessions=None,
             projects_dir=projects_dir,
             global_mode=global_mode,
         )
+    else:
+        raise ValueError(f"Unsupported backend {backend!r}. Expected one of: 'file', 'tmux'.")
 
     handler = _make_handler(store)
     server = ThreadingHTTPServer((host, port), handler)

--- a/src/betty/store.py
+++ b/src/betty/store.py
@@ -87,6 +87,21 @@ class EventStore:
         )
         self._project_watcher.start()
 
+    def start_watching_tmux(self, socket: str | None = None) -> None:
+        """Start watching tmux panes for Claude Code sessions.
+
+        Args:
+            socket: Optional tmux socket name (``-L`` flag).
+        """
+        from .tmux_backend import TmuxProjectWatcher
+
+        self._project_watcher = TmuxProjectWatcher(
+            on_session_discovered=self._on_session_discovered,
+            socket=socket,
+            on_initial_load_done=self._on_initial_load_done,
+        )
+        self._project_watcher.start()
+
     def _on_initial_load_done(self) -> None:
         """Called when ProjectWatcher finishes its initial scan."""
         with self._lock:

--- a/src/betty/store.py
+++ b/src/betty/store.py
@@ -4,7 +4,7 @@ import logging
 import threading
 from datetime import datetime
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Protocol
 
 from .agent import Agent
 from .agent_models import SessionReport
@@ -27,6 +27,11 @@ from .transcript import parse_transcript
 from .watcher import TranscriptWatcher
 
 # Maximum turns to keep in memory per session.
+# Protocol shared by ProjectWatcher and TmuxProjectWatcher so _project_watcher
+# can hold either without a type error.
+class _WatcherLike(Protocol):
+    def start(self) -> None: ...
+    def stop(self) -> None: ...
 # Older turns can be re-read from the transcript file on demand.
 MAX_TURNS_IN_MEMORY = 500
 
@@ -43,7 +48,7 @@ class EventStore:
         self._active_session_id: str | None = None
         self._enable_notifications = enable_notifications
         self._transcript_watchers: dict[str, TranscriptWatcher] = {}  # session_id -> watcher
-        self._project_watcher: ProjectWatcher | None = None
+        self._project_watcher: _WatcherLike | None = None
         self._initial_load_done = False  # Set after initial scan completes
         self._branch_cache: dict[str, str | None] = {}  # project_dir -> branch name
         self._pr_detector = PRDetector()

--- a/src/betty/tmux_backend.py
+++ b/src/betty/tmux_backend.py
@@ -6,7 +6,6 @@ Discovers Claude Code sessions by inspecting tmux panes for running
 """
 
 import logging
-import re
 import subprocess
 import threading
 from pathlib import Path
@@ -14,9 +13,12 @@ from typing import Callable
 
 logger = logging.getLogger(__name__)
 
+_tmux_not_found_warned = False
+
 
 def _run_tmux(args: list[str], socket: str | None = None, timeout: float = 5.0) -> str | None:
     """Run a tmux command and return stdout, or None on failure."""
+    global _tmux_not_found_warned
     cmd = ["tmux"]
     if socket:
         cmd.extend(["-L", socket])
@@ -27,7 +29,9 @@ def _run_tmux(args: list[str], socket: str | None = None, timeout: float = 5.0) 
             return result.stdout
         logger.debug("tmux %s returned %d: %s", args, result.returncode, result.stderr.strip())
     except FileNotFoundError:
-        logger.warning("tmux not found on PATH")
+        if not _tmux_not_found_warned:
+            logger.warning("tmux not found on PATH")
+            _tmux_not_found_warned = True
     except (subprocess.TimeoutExpired, OSError) as exc:
         logger.debug("tmux command failed: %s", exc)
     return None
@@ -150,10 +154,46 @@ def discover_sessions_from_tmux(
     seen_sessions: set[str] = set()
 
     panes = _get_pane_pids(socket=socket)
-    for pane_id, pane_pid in panes:
-        claude_procs = _find_claude_processes(pane_pid)
-        for proc in claude_procs:
-            cwd = proc["cwd"]
+    if not panes:
+        return discovered
+
+    # Build the process tree once for all panes (single ps invocation).
+    children: dict[str, list[str]] = {}
+    comm_by_pid: dict[str, str] = {}
+    try:
+        ps_result = subprocess.run(
+            ["ps", "-e", "-o", "pid,ppid,comm"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if ps_result.returncode == 0:
+            for line in ps_result.stdout.strip().splitlines()[1:]:  # skip header
+                parts = line.split()
+                if len(parts) >= 3:
+                    pid, ppid, comm = parts[0], parts[1], parts[2]
+                    children.setdefault(ppid, []).append(pid)
+                    comm_by_pid[pid] = comm
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+
+    for _, pane_pid in panes:
+        # BFS to find all descendants of this pane process.
+        descendants: set[str] = set()
+        queue = [pane_pid]
+        while queue:
+            p = queue.pop(0)
+            for child in children.get(p, []):
+                if child not in descendants:
+                    descendants.add(child)
+                    queue.append(child)
+
+        for pid in descendants:
+            comm = comm_by_pid.get(pid, "")
+            if "claude" not in comm.lower():
+                continue
+            cwd = _get_process_cwd(pid)
+            if not cwd:
+                continue
+
             encoded = _encode_project_path(cwd)
             project_path = projects_dir / encoded
 
@@ -224,20 +264,24 @@ class TmuxProjectWatcher:
         self._thread = threading.Thread(target=self._poll_loop, daemon=True)
         self._thread.start()
 
+    def _poll_once(self) -> None:
+        """Discover sessions and report any that are new. Called by the poll loop."""
+        sessions = discover_sessions_from_tmux(socket=self._socket)
+        for session_id, transcript_path in sessions:
+            if session_id not in self._known_sessions:
+                try:
+                    if transcript_path.stat().st_size > 0:
+                        self._known_sessions.add(session_id)
+                        self._on_session_discovered(session_id, transcript_path)
+                except (PermissionError, OSError):
+                    pass
+
     def _poll_loop(self) -> None:
         while self._running:
             self._stop_event.wait(timeout=self._poll_interval)
             if not self._running:
                 break
-            sessions = discover_sessions_from_tmux(socket=self._socket)
-            for session_id, transcript_path in sessions:
-                if session_id not in self._known_sessions:
-                    try:
-                        if transcript_path.stat().st_size > 0:
-                            self._known_sessions.add(session_id)
-                            self._on_session_discovered(session_id, transcript_path)
-                    except (PermissionError, OSError):
-                        pass
+            self._poll_once()
 
     def stop(self) -> None:
         self._running = False

--- a/src/betty/tmux_backend.py
+++ b/src/betty/tmux_backend.py
@@ -8,6 +8,7 @@ Discovers Claude Code sessions by inspecting tmux panes for running
 import logging
 import subprocess
 import threading
+from collections import deque
 from pathlib import Path
 from typing import Callable
 
@@ -54,6 +55,10 @@ def _find_claude_processes(pane_pid: str) -> list[dict]:
     """Find claude processes that are children of the given pane PID.
 
     Returns list of dicts with 'pid' and 'cwd' keys.
+
+    Note: This function issues its own ``ps`` call and is intentionally kept
+    separate from ``discover_sessions_from_tmux`` (which batches the call
+    across all panes) so that the BFS logic can be unit-tested in isolation.
     """
     # Use ps to find child processes that look like claude
     try:
@@ -79,9 +84,9 @@ def _find_claude_processes(pane_pid: str) -> list[dict]:
 
     # BFS to find all descendants
     descendants = set()
-    queue = [pane_pid]
+    queue: deque[str] = deque([pane_pid])
     while queue:
-        p = queue.pop(0)
+        p = queue.popleft()
         for child in children.get(p, []):
             if child not in descendants:
                 descendants.add(child)
@@ -178,9 +183,9 @@ def discover_sessions_from_tmux(
     for _, pane_pid in panes:
         # BFS to find all descendants of this pane process.
         descendants: set[str] = set()
-        queue = [pane_pid]
+        queue: deque[str] = deque([pane_pid])
         while queue:
-            p = queue.pop(0)
+            p = queue.popleft()
             for child in children.get(p, []):
                 if child not in descendants:
                     descendants.add(child)
@@ -244,13 +249,15 @@ class TmuxProjectWatcher:
 
     def start(self) -> None:
         """Initial scan and start polling."""
-        # Initial discovery
+        # Initial discovery — mirror _poll_once(): only mark known after
+        # confirming non-empty so files that are initially empty will be
+        # retried on the next poll cycle.
         sessions = discover_sessions_from_tmux(socket=self._socket)
         for session_id, transcript_path in sessions:
             if session_id not in self._known_sessions:
-                self._known_sessions.add(session_id)
                 try:
                     if transcript_path.stat().st_size > 0:
+                        self._known_sessions.add(session_id)
                         self._on_session_discovered(session_id, transcript_path)
                 except (PermissionError, OSError):
                     pass

--- a/src/betty/tmux_backend.py
+++ b/src/betty/tmux_backend.py
@@ -1,0 +1,246 @@
+"""Tmux-based session discovery backend.
+
+Discovers Claude Code sessions by inspecting tmux panes for running
+``claude`` processes, then locates their transcript files in
+``~/.claude/projects/``.
+"""
+
+import logging
+import re
+import subprocess
+import threading
+from pathlib import Path
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+
+def _run_tmux(args: list[str], socket: str | None = None, timeout: float = 5.0) -> str | None:
+    """Run a tmux command and return stdout, or None on failure."""
+    cmd = ["tmux"]
+    if socket:
+        cmd.extend(["-L", socket])
+    cmd.extend(args)
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        if result.returncode == 0:
+            return result.stdout
+        logger.debug("tmux %s returned %d: %s", args, result.returncode, result.stderr.strip())
+    except FileNotFoundError:
+        logger.warning("tmux not found on PATH")
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("tmux command failed: %s", exc)
+    return None
+
+
+def _get_pane_pids(socket: str | None = None) -> list[tuple[str, str]]:
+    """Get list of (pane_id, pane_pid) for all tmux panes."""
+    output = _run_tmux(["list-panes", "-a", "-F", "#{pane_id} #{pane_pid}"], socket=socket)
+    if not output:
+        return []
+    panes = []
+    for line in output.strip().splitlines():
+        parts = line.split(None, 1)
+        if len(parts) == 2:
+            panes.append((parts[0], parts[1]))
+    return panes
+
+
+def _find_claude_processes(pane_pid: str) -> list[dict]:
+    """Find claude processes that are children of the given pane PID.
+
+    Returns list of dicts with 'pid' and 'cwd' keys.
+    """
+    # Use ps to find child processes that look like claude
+    try:
+        # Get all descendants' command lines and CWDs
+        result = subprocess.run(
+            ["ps", "-e", "-o", "pid,ppid,comm"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode != 0:
+            return []
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return []
+
+    # Build parent-child tree to find descendants of pane_pid
+    children: dict[str, list[str]] = {}
+    comm_by_pid: dict[str, str] = {}
+    for line in result.stdout.strip().splitlines()[1:]:  # Skip header
+        parts = line.split()
+        if len(parts) >= 3:
+            pid, ppid, comm = parts[0], parts[1], parts[2]
+            children.setdefault(ppid, []).append(pid)
+            comm_by_pid[pid] = comm
+
+    # BFS to find all descendants
+    descendants = set()
+    queue = [pane_pid]
+    while queue:
+        p = queue.pop(0)
+        for child in children.get(p, []):
+            if child not in descendants:
+                descendants.add(child)
+                queue.append(child)
+
+    # Find claude processes among descendants
+    claude_procs = []
+    for pid in descendants:
+        comm = comm_by_pid.get(pid, "")
+        if "claude" in comm.lower():
+            # Get CWD from /proc (Linux) or lsof (macOS)
+            cwd = _get_process_cwd(pid)
+            if cwd:
+                claude_procs.append({"pid": pid, "cwd": cwd})
+
+    return claude_procs
+
+
+def _get_process_cwd(pid: str) -> str | None:
+    """Get the current working directory of a process."""
+    # Try /proc first (Linux)
+    proc_cwd = Path(f"/proc/{pid}/cwd")
+    try:
+        if proc_cwd.is_symlink():
+            return str(proc_cwd.resolve())
+    except (PermissionError, OSError):
+        pass
+
+    # Fallback: lsof (macOS/other)
+    try:
+        result = subprocess.run(
+            ["lsof", "-p", pid, "-Fn", "-a", "-d", "cwd"],
+            capture_output=True, text=True, timeout=3,
+        )
+        if result.returncode == 0:
+            for line in result.stdout.splitlines():
+                if line.startswith("n/"):
+                    return line[1:]
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+
+    return None
+
+
+def _encode_project_path(path: str) -> str:
+    """Encode an absolute path to Claude's project directory name."""
+    return "-" + path.lstrip("/").replace("/", "-")
+
+
+def discover_sessions_from_tmux(
+    socket: str | None = None,
+) -> list[tuple[str, Path]]:
+    """Discover Claude Code sessions from tmux panes.
+
+    Scans all tmux panes for running claude processes, determines their
+    working directories, and locates corresponding session transcript
+    files in ~/.claude/projects/.
+
+    Args:
+        socket: Optional tmux socket name (``-L`` flag).
+
+    Returns:
+        List of (session_id, transcript_path) tuples.
+    """
+    projects_dir = Path.home() / ".claude" / "projects"
+    if not projects_dir.exists():
+        return []
+
+    discovered: list[tuple[str, Path]] = []
+    seen_sessions: set[str] = set()
+
+    panes = _get_pane_pids(socket=socket)
+    for pane_id, pane_pid in panes:
+        claude_procs = _find_claude_processes(pane_pid)
+        for proc in claude_procs:
+            cwd = proc["cwd"]
+            encoded = _encode_project_path(cwd)
+            project_path = projects_dir / encoded
+
+            if not project_path.exists():
+                continue
+
+            # Find session files, sorted by mtime (most recent first)
+            try:
+                session_files = sorted(
+                    [f for f in project_path.iterdir() if f.suffix == ".jsonl" and f.is_file()],
+                    key=lambda f: f.stat().st_mtime,
+                    reverse=True,
+                )
+            except (PermissionError, OSError):
+                continue
+
+            for sf in session_files:
+                sid = sf.stem
+                if sid not in seen_sessions:
+                    seen_sessions.add(sid)
+                    discovered.append((sid, sf))
+
+    return discovered
+
+
+class TmuxProjectWatcher:
+    """Watch tmux panes for Claude Code sessions.
+
+    Drop-in replacement for ProjectWatcher that discovers sessions
+    by inspecting tmux panes instead of scanning directories.
+    """
+
+    def __init__(
+        self,
+        on_session_discovered: Callable[[str, Path], None],
+        socket: str | None = None,
+        poll_interval: float = 5.0,
+        on_initial_load_done: Callable[[], None] | None = None,
+    ):
+        self._on_session_discovered = on_session_discovered
+        self._socket = socket
+        self._poll_interval = poll_interval
+        self._on_initial_load_done = on_initial_load_done
+        self._known_sessions: set[str] = set()
+        self._running = False
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        """Initial scan and start polling."""
+        # Initial discovery
+        sessions = discover_sessions_from_tmux(socket=self._socket)
+        for session_id, transcript_path in sessions:
+            if session_id not in self._known_sessions:
+                self._known_sessions.add(session_id)
+                try:
+                    if transcript_path.stat().st_size > 0:
+                        self._on_session_discovered(session_id, transcript_path)
+                except (PermissionError, OSError):
+                    pass
+
+        if self._on_initial_load_done:
+            self._on_initial_load_done()
+
+        # Start polling thread
+        self._running = True
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._poll_loop, daemon=True)
+        self._thread.start()
+
+    def _poll_loop(self) -> None:
+        while self._running:
+            self._stop_event.wait(timeout=self._poll_interval)
+            if not self._running:
+                break
+            sessions = discover_sessions_from_tmux(socket=self._socket)
+            for session_id, transcript_path in sessions:
+                if session_id not in self._known_sessions:
+                    try:
+                        if transcript_path.stat().st_size > 0:
+                            self._known_sessions.add(session_id)
+                            self._on_session_discovered(session_id, transcript_path)
+                    except (PermissionError, OSError):
+                        pass
+
+    def stop(self) -> None:
+        self._running = False
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join(timeout=6.0)

--- a/tests/test_tmux_backend.py
+++ b/tests/test_tmux_backend.py
@@ -2,11 +2,8 @@
 
 import os
 import tempfile
-from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 from betty.tmux_backend import (
     TmuxProjectWatcher,
@@ -133,10 +130,11 @@ class TestDiscoverSessionsFromTmux:
             session_file = project_dir / "abc123.jsonl"
             session_file.write_text('{"type":"user"}\n')
 
-            # Mock the tmux/process functions
+            # Simulate: pane 1000 has a claude child process 1001
+            ps_output = "  PID  PPID COMMAND\n 1001 1000 claude\n"
             with patch("betty.tmux_backend._get_pane_pids", return_value=[("%0", "1000")]), \
-                 patch("betty.tmux_backend._find_claude_processes", return_value=[{"pid": "1001", "cwd": "/home/user/myproject"}]), \
-                 patch("betty.tmux_backend._encode_project_path", return_value="-home-user-myproject"), \
+                 patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=ps_output)), \
+                 patch("betty.tmux_backend._get_process_cwd", return_value="/home/user/myproject"), \
                  patch("pathlib.Path.home", return_value=Path(tmpdir)):
                 result = discover_sessions_from_tmux()
                 assert len(result) == 1
@@ -187,11 +185,11 @@ class TestTmuxProjectWatcher:
                     on_session_discovered=callback,
                 )
                 watcher.start()
-                # Manually trigger another poll cycle
-                watcher._poll_loop.__wrapped__ if hasattr(watcher._poll_loop, '__wrapped__') else None
+                # Explicitly trigger a second poll cycle to verify deduplication
+                watcher._poll_once()
                 watcher.stop()
 
-            # Should only be called once despite multiple scans
+            # Should only be called once despite two discovery cycles
             callback.assert_called_once()
 
     def test_skips_empty_files(self):

--- a/tests/test_tmux_backend.py
+++ b/tests/test_tmux_backend.py
@@ -1,0 +1,235 @@
+"""Tests for the tmux-based session discovery backend."""
+
+import os
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from betty.tmux_backend import (
+    TmuxProjectWatcher,
+    _encode_project_path,
+    _find_claude_processes,
+    _get_pane_pids,
+    _get_process_cwd,
+    discover_sessions_from_tmux,
+)
+
+
+class TestEncodeProjectPath:
+    def test_basic(self):
+        assert _encode_project_path("/home/user/project") == "-home-user-project"
+
+    def test_trailing_slash(self):
+        assert _encode_project_path("/home/user/project/") == "-home-user-project-"
+
+    def test_root(self):
+        assert _encode_project_path("/") == "-"
+
+
+class TestGetPanePids:
+    @patch("betty.tmux_backend._run_tmux")
+    def test_parses_output(self, mock_run):
+        mock_run.return_value = "%0 12345\n%1 67890\n"
+        result = _get_pane_pids()
+        assert result == [("%0", "12345"), ("%1", "67890")]
+        mock_run.assert_called_once_with(
+            ["list-panes", "-a", "-F", "#{pane_id} #{pane_pid}"], socket=None
+        )
+
+    @patch("betty.tmux_backend._run_tmux")
+    def test_with_socket(self, mock_run):
+        mock_run.return_value = "%0 111\n"
+        result = _get_pane_pids(socket="mysock")
+        mock_run.assert_called_once_with(
+            ["list-panes", "-a", "-F", "#{pane_id} #{pane_pid}"], socket="mysock"
+        )
+
+    @patch("betty.tmux_backend._run_tmux")
+    def test_empty(self, mock_run):
+        mock_run.return_value = None
+        assert _get_pane_pids() == []
+
+    @patch("betty.tmux_backend._run_tmux")
+    def test_blank(self, mock_run):
+        mock_run.return_value = ""
+        assert _get_pane_pids() == []
+
+
+class TestGetProcessCwd:
+    def test_current_process(self):
+        """Our own process has a /proc entry on Linux."""
+        pid = str(os.getpid())
+        cwd = _get_process_cwd(pid)
+        if Path(f"/proc/{pid}/cwd").exists():
+            assert cwd is not None
+            assert Path(cwd).is_dir()
+
+    def test_nonexistent_pid(self):
+        cwd = _get_process_cwd("9999999")
+        # Should return None (process doesn't exist)
+        assert cwd is None
+
+
+class TestFindClaudeProcesses:
+    @patch("subprocess.run")
+    @patch("betty.tmux_backend._get_process_cwd")
+    def test_finds_claude_child(self, mock_cwd, mock_run):
+        # Simulate ps output with a claude process as child of pane PID
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=(
+                "  PID  PPID COMMAND\n"
+                " 1000  999 bash\n"
+                " 1001 1000 claude\n"
+                " 1002 1001 node\n"
+            ),
+        )
+        mock_cwd.return_value = "/home/user/project"
+
+        result = _find_claude_processes("1000")
+        assert len(result) == 1
+        assert result[0]["pid"] == "1001"
+        assert result[0]["cwd"] == "/home/user/project"
+
+    @patch("subprocess.run")
+    def test_no_claude_children(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=(
+                "  PID  PPID COMMAND\n"
+                " 1000  999 bash\n"
+                " 1001 1000 vim\n"
+            ),
+        )
+        result = _find_claude_processes("1000")
+        assert result == []
+
+    @patch("subprocess.run")
+    def test_ps_failure(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        result = _find_claude_processes("1000")
+        assert result == []
+
+
+class TestDiscoverSessionsFromTmux:
+    def test_no_tmux(self):
+        """When tmux is not available, returns empty list."""
+        with patch("betty.tmux_backend._get_pane_pids", return_value=[]):
+            result = discover_sessions_from_tmux()
+            assert result == []
+
+    def test_discovers_sessions(self):
+        """Integration test with temp directory simulating ~/.claude/projects/."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Set up fake projects dir
+            projects_dir = Path(tmpdir) / ".claude" / "projects"
+            project_dir = projects_dir / "-home-user-myproject"
+            project_dir.mkdir(parents=True)
+
+            # Create a session file
+            session_file = project_dir / "abc123.jsonl"
+            session_file.write_text('{"type":"user"}\n')
+
+            # Mock the tmux/process functions
+            with patch("betty.tmux_backend._get_pane_pids", return_value=[("%0", "1000")]), \
+                 patch("betty.tmux_backend._find_claude_processes", return_value=[{"pid": "1001", "cwd": "/home/user/myproject"}]), \
+                 patch("betty.tmux_backend._encode_project_path", return_value="-home-user-myproject"), \
+                 patch("pathlib.Path.home", return_value=Path(tmpdir)):
+                result = discover_sessions_from_tmux()
+                assert len(result) == 1
+                assert result[0][0] == "abc123"
+                assert result[0][1] == session_file
+
+
+class TestTmuxProjectWatcher:
+    def test_initial_discovery(self):
+        """Watcher calls on_session_discovered for initial sessions."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            projects_dir = Path(tmpdir) / ".claude" / "projects"
+            project_dir = projects_dir / "-home-user-proj"
+            project_dir.mkdir(parents=True)
+
+            sf = project_dir / "sess1.jsonl"
+            sf.write_text('{"type":"user"}\n')
+
+            callback = MagicMock()
+            initial_done = MagicMock()
+
+            with patch("betty.tmux_backend.discover_sessions_from_tmux", return_value=[("sess1", sf)]):
+                watcher = TmuxProjectWatcher(
+                    on_session_discovered=callback,
+                    on_initial_load_done=initial_done,
+                )
+                watcher.start()
+                watcher.stop()
+
+            callback.assert_called_once_with("sess1", sf)
+            initial_done.assert_called_once()
+
+    def test_deduplicates(self):
+        """Watcher doesn't call callback twice for same session."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            projects_dir = Path(tmpdir) / ".claude" / "projects"
+            project_dir = projects_dir / "-home-user-proj"
+            project_dir.mkdir(parents=True)
+
+            sf = project_dir / "sess1.jsonl"
+            sf.write_text('{"type":"user"}\n')
+
+            callback = MagicMock()
+
+            # discover returns same session on both calls
+            with patch("betty.tmux_backend.discover_sessions_from_tmux", return_value=[("sess1", sf)]):
+                watcher = TmuxProjectWatcher(
+                    on_session_discovered=callback,
+                )
+                watcher.start()
+                # Manually trigger another poll cycle
+                watcher._poll_loop.__wrapped__ if hasattr(watcher._poll_loop, '__wrapped__') else None
+                watcher.stop()
+
+            # Should only be called once despite multiple scans
+            callback.assert_called_once()
+
+    def test_skips_empty_files(self):
+        """Watcher skips session files with zero size."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            projects_dir = Path(tmpdir) / ".claude" / "projects"
+            project_dir = projects_dir / "-home-user-proj"
+            project_dir.mkdir(parents=True)
+
+            sf = project_dir / "empty.jsonl"
+            sf.write_text("")
+
+            callback = MagicMock()
+
+            with patch("betty.tmux_backend.discover_sessions_from_tmux", return_value=[("empty", sf)]):
+                watcher = TmuxProjectWatcher(
+                    on_session_discovered=callback,
+                )
+                watcher.start()
+                watcher.stop()
+
+            callback.assert_not_called()
+
+
+class TestSessionDataShape:
+    """Verify tmux backend produces same session data shape as file backend."""
+
+    def test_session_has_expected_fields(self):
+        """Sessions from tmux backend are regular Session objects."""
+        from betty.models import Session
+
+        # TmuxProjectWatcher calls EventStore._on_session_discovered
+        # which creates Session objects - same as ProjectWatcher.
+        # Verify this by checking the callback signature matches.
+        from betty.store import EventStore
+        import inspect
+
+        sig = inspect.signature(EventStore._on_session_discovered)
+        params = list(sig.parameters.keys())
+        assert "session_id" in params
+        assert "transcript_path" in params


### PR DESCRIPTION
## Summary
- Add `--backend tmux` option to `betty server` that discovers Claude Code sessions by inspecting tmux panes for running `claude` processes
- Support custom tmux socket path via `--tmux-socket <name>`
- `TmuxProjectWatcher` is a drop-in replacement for `ProjectWatcher`, using the same `EventStore._on_session_discovered` callback — same session data shape
- Discovers CWD from `/proc/<pid>/cwd` (Linux) or `lsof` (macOS), then maps to `~/.claude/projects/<encoded-cwd>/` transcript files

Closes #188

## Test plan
- [x] `betty server --backend tmux` discovers sessions from tmux panes
- [x] `betty server --backend tmux --tmux-socket main` uses custom socket
- [x] Session data shape matches file backend (same Session/Turn objects)
- [x] Empty session files are skipped
- [x] Deduplication works across poll cycles
- [x] All 18 new tests pass (`pytest tests/test_tmux_backend.py`)
- [x] All existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)